### PR TITLE
Fix secondary description method typo

### DIFF
--- a/ValueSequencer/CHexagramValueSequencer.cs
+++ b/ValueSequencer/CHexagramValueSequencer.cs
@@ -220,22 +220,22 @@ namespace ValueSequencer
 			return HexagramId() + " " + Label + (bValue ? " (" + ValueStr + ")" : "");
 		}
 
-		public String DescibeSecondary(bool bValue = false)
+                public String DescribeSecondary(bool bValue = false)
 		{
 			if (IsMoving)
 			{
 				CHexagramValueSequencer hvsPrimary = this;
-				CHexagramValueSequencer hvsSeconday = new CHexagramValueSequencer(ref hvsPrimary);
-				hvsSeconday.Move();
-				return hvsSeconday.HexagramId() + " " + hvsSeconday.Label + (bValue ? " (" + hvsSeconday.ValueStr + ")" : "");
-			}
-			return "";
-		}
+                                CHexagramValueSequencer hvsSecondary = new CHexagramValueSequencer(ref hvsPrimary);
+                                hvsSecondary.Move();
+                                return hvsSecondary.HexagramId() + " " + hvsSecondary.Label + (bValue ? " (" + hvsSecondary.ValueStr + ")" : "");
+                        }
+                        return "";
+                }
 
 		public String DescribeCast(bool bValue = false)
 		{
-			return DescribePrimary(bValue) + (IsMoving ? " > " + DescibeSecondary(bValue) : "");
-		}
+                        return DescribePrimary(bValue) + (IsMoving ? " > " + DescribeSecondary(bValue) : "");
+                }
 
 		protected override int GetCurrentSequence() { return m_nCurrentSequence; }
 		protected override int GetCurrentRatio() { return m_nCurrentRatio; }


### PR DESCRIPTION
## Summary
- Rename `DescibeSecondary` to `DescribeSecondary`
- Fix `hvsSeconday` variable typo to `hvsSecondary`
- Update `DescribeCast` to call new `DescribeSecondary`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac461efd5c832b947d174a28c4fab4