### PR TITLE
Track EEG channel initialization

### DIFF
--- a/Yijing.maui/Services/Eeg.cs
+++ b/Yijing.maui/Services/Eeg.cs
@@ -18,8 +18,8 @@ namespace Yijing.Services;
 
 public class EegChannel
 {
-	public ArrayList m_alAverage = new();
-	public float m_fCurrentValue = 0.0f;
+        public ArrayList m_alAverage = new();
+        public float m_fCurrentValue = 0.0f;
 	//public float m_fMinValue = 0.0f;
 	//public float m_fMaxValue = 0.0f;
 
@@ -31,21 +31,26 @@ public class EegChannel
 
 	public bool m_isTrigger = false;
 
-	public static int m_nAverageMax = 100;
+        public bool m_isInitialised = false;
 
-	public EegChannel(int nAverageMax)
-	{
-		m_nAverageMax = nAverageMax;
-		m_alAverage.Clear();
-		InitialseChannel(0.0f);
-	}
+        public static int m_nAverageMax = 100;
 
-	public void InitialseChannel(float f)
-	{
-		if (m_alAverage.Count == 0)
-			for (int j = 0; j < m_nAverageMax; ++j)
-				m_alAverage.Add(f);
-	}
+        public EegChannel(int nAverageMax)
+        {
+                m_nAverageMax = nAverageMax;
+                m_alAverage.Clear();
+                for (int j = 0; j < m_nAverageMax; ++j)
+                        m_alAverage.Add(0.0f);
+                m_isInitialised = false;
+        }
+
+        public void InitialseChannel(float f)
+        {
+                m_alAverage.Clear();
+                for (int j = 0; j < m_nAverageMax; ++j)
+                        m_alAverage.Add(f);
+                m_isInitialised = true;
+        }
 }
 
 // //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -254,9 +259,12 @@ public class Eeg
 				}
 			}
 
-			//m_eegChannel[i].InitialseChannel(f);
+                        //m_eegChannel[i].InitialseChannel(f);
 
-			m_eegChannel[i].m_alAverage.Insert(0, f);
+                        if (!m_eegChannel[i].m_isInitialised)
+                                m_eegChannel[i].InitialseChannel(f);
+
+                        m_eegChannel[i].m_alAverage.Insert(0, f);
 			m_eegChannel[i].m_alAverage.RemoveAt(EegChannel.m_nAverageMax);
 			for (int j = 0; j < EegChannel.m_nAverageMax; ++j)
 				sum += (float)m_eegChannel[i].m_alAverage[j];


### PR DESCRIPTION
## Summary
- Add `m_isInitialised` flag to `EegChannel` to track when real samples populate the buffer
- Reset channel buffer and flag in `InitialseChannel`
- Initialize each channel with first real sample before averaging

## Testing
- `dotnet build Yijing.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aea1687528832b995e26bea59e3edb