### PR TITLE
Add time axis to EEG chart

### DIFF
--- a/Yijing.maui/Pages/EegPage.xaml.cs
+++ b/Yijing.maui/Pages/EegPage.xaml.cs
@@ -1,8 +1,10 @@
-﻿using LiveChartsCore.Measure;
+﻿using LiveChartsCore;
+using LiveChartsCore.Measure;
 using LiveChartsCore.SkiaSharpView;
 using LiveChartsCore.SkiaSharpView.Maui;
 
 using Yijing.Models;
+using Yijing.Services;
 
 namespace Yijing.Pages;
 
@@ -14,27 +16,33 @@ public partial class EegPage : ContentPage
 	public static Editor SessionLog() { return _this.edtSessionLog; }
 	public static CartesianChart CartesianChart() { return _this.chaEeg; }
 
-	public EegPage()
-	{
-		_this = this;
+        private const double SecondsPerSample = 0.15;
 
-		InitializeComponent();
+        public EegPage()
+        {
+                _this = this;
 
-		EegSeries eegChart = new();
-		var xAxis = new Axis
-		{
-			Labels = new[] { "" }
-		};
+                InitializeComponent();
 
-		chaEeg.Series = eegChart.Series;
-		chaEeg.XAxes = new List<Axis> { xAxis };
-		chaEeg.TooltipPosition = TooltipPosition.Hidden;
-		chaEeg.ZoomMode = ZoomAndPanMode.None;
-		chaEeg.LegendPosition = LegendPosition.Hidden;
-		chaEeg.AnimationsSpeed = new TimeSpan();
-		chaEeg.AutoUpdateEnabled = true;
+                EegSeries eegChart = new();
+                int seriesMax = (AppPreferences.ChartTime + 1) * 1000;
+                var xAxis = new Axis
+                {
+                        Name = "Time",
+                        MinLimit = 0,
+                        MaxLimit = seriesMax,
+                        Labeler = value => TimeSpan.FromSeconds(value * SecondsPerSample).ToString(@"mm\\:ss")
+                };
 
-	}
+                chaEeg.Series = eegChart.Series;
+                chaEeg.XAxes = new List<Axis> { xAxis };
+                chaEeg.TooltipPosition = TooltipPosition.Hidden;
+                chaEeg.ZoomMode = ZoomAndPanMode.None;
+                chaEeg.LegendPosition = LegendPosition.Hidden;
+                chaEeg.AnimationsSpeed = new TimeSpan();
+                chaEeg.AutoUpdateEnabled = true;
+
+        }
 
 	private void Page_Loaded(object sender, EventArgs e)
 	{

--- a/Yijing.maui/Views/EegView.xaml.cs
+++ b/Yijing.maui/Views/EegView.xaml.cs
@@ -300,10 +300,12 @@ public partial class EegView : ContentView
 		}
 	}
 
-	private void picChartTime_SelectedIndexChanged(object sender, EventArgs e)
-	{
-		m_nSeriesMax = (picChartTime.SelectedIndex + 1) * 1000;
-	}
+        private void picChartTime_SelectedIndexChanged(object sender, EventArgs e)
+        {
+                m_nSeriesMax = (picChartTime.SelectedIndex + 1) * 1000;
+                if (EegPage.CartesianChart() != null && EegPage.CartesianChart().XAxes.Count > 0)
+                        EegPage.CartesianChart().XAxes[0].MaxLimit = m_nSeriesMax;
+        }
 
 	private void picTriggerChannel_SelectedIndexChanged(object sender, EventArgs e)
 	{


### PR DESCRIPTION
## Summary
- Add time-based X axis to EEG chart with mm:ss labels
- Keep X axis in sync with chart duration selections

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aea8447674832b85469db3710537b7