### PR TITLE
Add privacy policy for AI chat

### DIFF
--- a/Yijing.maui/Resources/Raw/PrivacyPolicy/index.html
+++ b/Yijing.maui/Resources/Raw/PrivacyPolicy/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Yijing Privacy Policy</title>
+  <style>body{font-family:Arial,sans-serif;margin:40px;line-height:1.6;} h1,h2{color:#2c3e50;}</style>
+</head>
+<body>
+  <h1>Privacy Policy</h1>
+  <p>Last updated: <span id="last-updated"></span></p>
+  <p>Yijing respects your privacy. This policy describes how the app handles your data.</p>
+  <h2>Data Collection and Use</h2>
+  <p>The app provides optional AI chat features. When you use AI chat, the text you enter and the AI's responses are sent to a third-party AI service solely to generate replies. The app does not retain this data after the conversation or transmit it elsewhere.</p>
+  <h2>Local Storage</h2>
+  <p>Apart from AI chat, the app stores files only on your device under <code>Documents\\Yijing</code>. These files remain on your device and are not uploaded or shared.</p>
+  <h2>Data Sharing</h2>
+  <p>Yijing does not collect personal information, track users, or share data with other parties.</p>
+  <h2>Your Choices</h2>
+  <p>You may stop using the AI chat feature at any time. To remove data saved in <code>Documents\\Yijing</code>, delete the folder.</p>
+  <h2>Contact</h2>
+  <p>If you have questions or concerns about this policy, please contact the developer through the support information provided in the app's Microsoft Store listing or via the project's repository.</p>
+  <script>
+    document.getElementById('last-updated').textContent = new Date().toISOString().split('T')[0];
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add HTML privacy policy describing AI chat data handling and local storage

## Testing
- `apt-get update` *(fails: 403 Forbidden)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b507600874832b9f65a9568d7d9c94