### PR TITLE
feat: switch to OllamaSharp for AI chat

### DIFF
--- a/Yijing.maui/Yijing.maui.csproj
+++ b/Yijing.maui/Yijing.maui.csproj
@@ -81,10 +81,10 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.9" />
 
-		<PackageReference Include="Microsoft.Extensions.AI" Version="9.9.0" />
-		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.9.0" />
-		<PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.8.0-preview.1.25412.6" />
-		<PackageReference Include="Microsoft.Extensions.AI.Ollama" Version="9.7.0-preview.1.25356.2" />
+                <PackageReference Include="Microsoft.Extensions.AI" Version="9.9.0" />
+                <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.9.0" />
+                <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.8.0-preview.1.25412.6" />
+                <PackageReference Include="OllamaSharp" Version="*" />
 
 		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.110" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.110" />


### PR DESCRIPTION
## Summary
- use OllamaSharp client instead of Microsoft.Extensions.AI.Ollama in DiagramView's AiChat
- add OllamaSharp package reference

## Testing
- `dotnet build Yijing.maui/Yijing.maui.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c126907820832bbbb6f3b9931fe236