### PR TITLE
Add Appium UI test scaffold for DiagramView

### DIFF
--- a/Yijing.maui.test/DiagramViewAutoCastTests.cs
+++ b/Yijing.maui.test/DiagramViewAutoCastTests.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Appium;
+using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
+using OpenQA.Selenium.Support.UI;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Yijing.Maui.Test;
+
+public sealed class DiagramViewAutoCastTests : IAsyncLifetime
+{
+    private readonly string? _skipReason;
+    private readonly Uri? _serverUri;
+    private readonly AppiumOptions? _options;
+    private readonly string? _platformName;
+    private AppiumDriver<AppiumWebElement>? _driver;
+
+    public DiagramViewAutoCastTests()
+    {
+        var serverUrl = Environment.GetEnvironmentVariable("YIJING_APPIUM_SERVER_URL");
+        var platformName = Environment.GetEnvironmentVariable("YIJING_APPIUM_PLATFORM");
+
+        if (string.IsNullOrWhiteSpace(serverUrl) || string.IsNullOrWhiteSpace(platformName))
+        {
+            _skipReason = "Set YIJING_APPIUM_SERVER_URL and YIJING_APPIUM_PLATFORM to run Appium UI tests.";
+            return;
+        }
+
+        _serverUri = new Uri(serverUrl);
+        _platformName = platformName.ToLowerInvariant();
+        _options = new AppiumOptions
+        {
+            PlatformName = platformName,
+        };
+
+        var automationName = Environment.GetEnvironmentVariable("YIJING_APPIUM_AUTOMATION_NAME");
+        if (string.IsNullOrWhiteSpace(automationName))
+        {
+            automationName = _platformName switch
+            {
+                "android" => "uiautomator2",
+                "ios" => "XCUITest",
+                "windows" => "Windows",
+                _ => null,
+            };
+        }
+
+        if (!string.IsNullOrWhiteSpace(automationName))
+        {
+            _options.AddAdditionalCapability("automationName", automationName);
+        }
+
+        foreach (var (capability, variable) in new (string capability, string variable)[]
+        {
+            ("app", "YIJING_APPIUM_APP_ID"),
+            ("appPackage", "YIJING_APPIUM_APP_PACKAGE"),
+            ("appActivity", "YIJING_APPIUM_APP_ACTIVITY"),
+            ("deviceName", "YIJING_APPIUM_DEVICE_NAME"),
+            ("platformVersion", "YIJING_APPIUM_PLATFORM_VERSION"),
+        })
+        {
+            var value = Environment.GetEnvironmentVariable(variable);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                _options.AddAdditionalCapability(capability, value);
+            }
+        }
+    }
+
+    public Task InitializeAsync()
+    {
+        if (_skipReason is not null)
+        {
+            return Task.CompletedTask;
+        }
+
+        _driver = _platformName switch
+        {
+            "android" => new AndroidDriver<AppiumWebElement>(_serverUri!, _options!, TimeSpan.FromSeconds(180)),
+            "ios" => new IOSDriver<AppiumWebElement>(_serverUri!, _options!, TimeSpan.FromSeconds(180)),
+            "windows" => new WindowsDriver<AppiumWebElement>(_serverUri!, _options!, TimeSpan.FromSeconds(180)),
+            _ => throw new NotSupportedException($"Unsupported platform '{_platformName}'."),
+        };
+
+        _driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(5);
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        _driver?.Quit();
+        _driver?.Dispose();
+        _driver = null;
+        return Task.CompletedTask;
+    }
+
+    [Fact(DisplayName = "AutoCast")]
+    public void AutoCast()
+    {
+        if (_skipReason is not null)
+        {
+            throw new SkipException(_skipReason);
+        }
+
+        if (_driver is null)
+        {
+            throw new InvalidOperationException("Appium driver was not initialised.");
+        }
+
+        var wait = new WebDriverWait(new SystemClock(), _driver, TimeSpan.FromSeconds(60), TimeSpan.FromMilliseconds(500));
+
+        var diagramModePicker = wait.Until(driver =>
+            FindElement((AppiumDriver<AppiumWebElement>)driver, new[]
+            {
+                MobileBy.AccessibilityId("picDiagramMode"),
+                MobileBy.Id("picDiagramMode"),
+                By.XPath("//*[contains(@text,'Diagram Mode')]/following::*[1]")
+            }) ?? throw new NoSuchElementException("Diagram mode picker not found."));
+
+        diagramModePicker.Click();
+
+        var autoCastOption = wait.Until(driver =>
+            FindElement((AppiumDriver<AppiumWebElement>)driver, new[]
+            {
+                MobileBy.AccessibilityId("Auto Cast"),
+                MobileBy.Name("Auto Cast"),
+                By.XPath("//*[contains(@text,'Auto Cast') or contains(@name,'Auto Cast')]")
+            }) ?? throw new NoSuchElementException("Unable to locate the Auto Cast option."));
+
+        autoCastOption.Click();
+
+        wait.Until(_ =>
+        {
+            var selected = GetElementText(diagramModePicker);
+            return selected?.Contains("Auto Cast", StringComparison.OrdinalIgnoreCase) == true;
+        });
+
+        var selectedText = GetElementText(diagramModePicker);
+        Assert.Contains("Auto Cast", selectedText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static AppiumWebElement? FindElement(AppiumDriver<AppiumWebElement> driver, IEnumerable<By> selectors)
+    {
+        foreach (var selector in selectors)
+        {
+            try
+            {
+                var element = driver.FindElement(selector);
+                if (element is not null)
+                {
+                    return element;
+                }
+            }
+            catch (NoSuchElementException)
+            {
+                // Try the next selector.
+            }
+        }
+
+        return null;
+    }
+
+    private static string? GetElementText(AppiumWebElement element)
+    {
+        var text = element.Text;
+        if (!string.IsNullOrWhiteSpace(text))
+        {
+            return text;
+        }
+
+        var value = element.GetAttribute("value");
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            return value;
+        }
+
+        var name = element.GetAttribute("Name");
+        if (!string.IsNullOrWhiteSpace(name))
+        {
+            return name;
+        }
+
+        return null;
+    }
+}

--- a/Yijing.maui.test/Yijing.maui.test.csproj
+++ b/Yijing.maui.test/Yijing.maui.test.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Appium.WebDriver" Version="8.0.0" />
+    <PackageReference Include="Selenium.Support" Version="4.35.0" />
+  </ItemGroup>
+</Project>

--- a/Yijing.sln
+++ b/Yijing.sln
@@ -14,6 +14,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EegML", "EegML\EegML.csproj
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yijing.db", "Yijing.db\Yijing.db.csproj", "{A9C767AD-CECD-B7AC-5A8E-47DAF85C1351}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yijing.maui.test", "Yijing.maui.test\Yijing.maui.test.csproj", "{2767AD26-70D8-4289-9FF5-FFF75F5140AF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -98,11 +100,23 @@ Global
 		{A9C767AD-CECD-B7AC-5A8E-47DAF85C1351}.Debug|x86.Build.0 = Debug|Any CPU
 		{A9C767AD-CECD-B7AC-5A8E-47DAF85C1351}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A9C767AD-CECD-B7AC-5A8E-47DAF85C1351}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A9C767AD-CECD-B7AC-5A8E-47DAF85C1351}.Release|x64.ActiveCfg = Release|Any CPU
-		{A9C767AD-CECD-B7AC-5A8E-47DAF85C1351}.Release|x64.Build.0 = Release|Any CPU
-		{A9C767AD-CECD-B7AC-5A8E-47DAF85C1351}.Release|x86.ActiveCfg = Release|Any CPU
-		{A9C767AD-CECD-B7AC-5A8E-47DAF85C1351}.Release|x86.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {A9C767AD-CECD-B7AC-5A8E-47DAF85C1351}.Release|x64.ActiveCfg = Release|Any CPU
+                {A9C767AD-CECD-B7AC-5A8E-47DAF85C1351}.Release|x64.Build.0 = Release|Any CPU
+                {A9C767AD-CECD-B7AC-5A8E-47DAF85C1351}.Release|x86.ActiveCfg = Release|Any CPU
+                {A9C767AD-CECD-B7AC-5A8E-47DAF85C1351}.Release|x86.Build.0 = Release|Any CPU
+                {2767AD26-70D8-4289-9FF5-FFF75F5140AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {2767AD26-70D8-4289-9FF5-FFF75F5140AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {2767AD26-70D8-4289-9FF5-FFF75F5140AF}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {2767AD26-70D8-4289-9FF5-FFF75F5140AF}.Debug|x64.Build.0 = Debug|Any CPU
+                {2767AD26-70D8-4289-9FF5-FFF75F5140AF}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {2767AD26-70D8-4289-9FF5-FFF75F5140AF}.Debug|x86.Build.0 = Debug|Any CPU
+                {2767AD26-70D8-4289-9FF5-FFF75F5140AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {2767AD26-70D8-4289-9FF5-FFF75F5140AF}.Release|Any CPU.Build.0 = Release|Any CPU
+                {2767AD26-70D8-4289-9FF5-FFF75F5140AF}.Release|x64.ActiveCfg = Release|Any CPU
+                {2767AD26-70D8-4289-9FF5-FFF75F5140AF}.Release|x64.Build.0 = Release|Any CPU
+                {2767AD26-70D8-4289-9FF5-FFF75F5140AF}.Release|x86.ActiveCfg = Release|Any CPU
+                {2767AD26-70D8-4289-9FF5-FFF75F5140AF}.Release|x86.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add a new `Yijing.maui.test` xUnit project for MAUI UI automation
- reference the Appium.WebDriver and Selenium.Support packages alongside standard test tooling
- implement an `AutoCast` Appium test that drives the DiagramView picker to the Auto Cast mode and gracefully skips when Appium is not configured

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0f034f44832b9d895354d79aae88