### PR TITLE
Add Blazor web project with diagram page

### DIFF
--- a/ValueSequencer/CHexagramSequences.cs
+++ b/ValueSequencer/CHexagramSequences.cs
@@ -5,9 +5,20 @@ using System.Text;
 
 namespace ValueSequencer
 {
-	public class CHexagramSequences
-	{
-	}
+        public class CHexagramSequences
+        {
+                public CHexagramValueSequencer AutoCast(ref CHexagramValueSequencer hvs)
+                {
+                        Random r = Sequences.m_ranSession ?? new Random(DateTime.Now.Millisecond);
+                        for (int l = 0; l < 6; ++l)
+                        {
+                                int count = (r.Next(5) + 1) * 100 + r.Next(100);
+                                for (int c = 0; c < count; ++c)
+                                        hvs.Trigram(l / 3).Line(l % 3).Next(true);
+                        }
+                        return hvs;
+                }
+        }
 	public class CHexagram : IComparable
 	{
 		public CHexagram(ref CHexagramValueSequencer hvsPrimary)

--- a/Yijing.sln
+++ b/Yijing.sln
@@ -16,6 +16,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yijing.db", "Yijing.db\Yiji
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yijing.maui.test", "Yijing.maui.test\Yijing.maui.test.csproj", "{2767AD26-70D8-4289-9FF5-FFF75F5140AF}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yijing.web", "Yijing.web\Yijing.web.csproj", "{A0DE2C8C-DE26-4B80-B6EF-F4E0A7EDD30A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -114,9 +116,21 @@ Global
 		{2767AD26-70D8-4289-9FF5-FFF75F5140AF}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2767AD26-70D8-4289-9FF5-FFF75F5140AF}.Release|x64.ActiveCfg = Release|Any CPU
 		{2767AD26-70D8-4289-9FF5-FFF75F5140AF}.Release|x64.Build.0 = Release|Any CPU
-		{2767AD26-70D8-4289-9FF5-FFF75F5140AF}.Release|x86.ActiveCfg = Release|Any CPU
-		{2767AD26-70D8-4289-9FF5-FFF75F5140AF}.Release|x86.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {2767AD26-70D8-4289-9FF5-FFF75F5140AF}.Release|x86.ActiveCfg = Release|Any CPU
+                {2767AD26-70D8-4289-9FF5-FFF75F5140AF}.Release|x86.Build.0 = Release|Any CPU
+                {A0DE2C8C-DE26-4B80-B6EF-F4E0A7EDD30A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {A0DE2C8C-DE26-4B80-B6EF-F4E0A7EDD30A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {A0DE2C8C-DE26-4B80-B6EF-F4E0A7EDD30A}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {A0DE2C8C-DE26-4B80-B6EF-F4E0A7EDD30A}.Debug|x64.Build.0 = Debug|Any CPU
+                {A0DE2C8C-DE26-4B80-B6EF-F4E0A7EDD30A}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {A0DE2C8C-DE26-4B80-B6EF-F4E0A7EDD30A}.Debug|x86.Build.0 = Debug|Any CPU
+                {A0DE2C8C-DE26-4B80-B6EF-F4E0A7EDD30A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {A0DE2C8C-DE26-4B80-B6EF-F4E0A7EDD30A}.Release|Any CPU.Build.0 = Release|Any CPU
+                {A0DE2C8C-DE26-4B80-B6EF-F4E0A7EDD30A}.Release|x64.ActiveCfg = Release|Any CPU
+                {A0DE2C8C-DE26-4B80-B6EF-F4E0A7EDD30A}.Release|x64.Build.0 = Release|Any CPU
+                {A0DE2C8C-DE26-4B80-B6EF-F4E0A7EDD30A}.Release|x86.ActiveCfg = Release|Any CPU
+                {A0DE2C8C-DE26-4B80-B6EF-F4E0A7EDD30A}.Release|x86.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/Yijing.web/App.razor
+++ b/Yijing.web/App.razor
@@ -1,0 +1,10 @@
+<Router AppAssembly="typeof(Program).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="routeData" DefaultLayout="typeof(Shared.MainLayout)" />
+    </Found>
+    <NotFound>
+        <LayoutView Layout="typeof(Shared.MainLayout)">
+            <p role="alert">Sorry, there's nothing at this address.</p>
+        </LayoutView>
+    </NotFound>
+</Router>

--- a/Yijing.web/App.razor
+++ b/Yijing.web/App.razor
@@ -1,9 +1,9 @@
-<Router AppAssembly="typeof(Program).Assembly">
+<Router AppAssembly="@typeof(Program).Assembly">
     <Found Context="routeData">
-        <RouteView RouteData="routeData" DefaultLayout="typeof(Shared.MainLayout)" />
+        <RouteView RouteData="@routeData" DefaultLayout="@typeof(Shared.MainLayout)" />
     </Found>
     <NotFound>
-        <LayoutView Layout="typeof(Shared.MainLayout)">
+        <LayoutView Layout="@typeof(Shared.MainLayout)">
             <p role="alert">Sorry, there's nothing at this address.</p>
         </LayoutView>
     </NotFound>

--- a/Yijing.web/Pages/Diagram.razor
+++ b/Yijing.web/Pages/Diagram.razor
@@ -68,12 +68,16 @@ else
                         <div class="hex-line @(line.IsYang ? "yang" : "yin") @(line.IsMoving ? "moving" : string.Empty)">
                             <span class="line-index">Line @line.Index</span>
                             <div class="segments">
-                                <div class="segment"></div>
-                                @if (!line.IsYang)
+                                @if (line.IsYang)
                                 {
-                                    <div class="gap"></div>
+                                    <div class="segment full"></div>
                                 }
-                                <div class="segment"></div>
+                                else
+                                {
+                                    <div class="segment"></div>
+                                    <div class="gap"></div>
+                                    <div class="segment"></div>
+                                }
                             </div>
                             <span class="line-label">@line.Label</span>
                         </div>

--- a/Yijing.web/Pages/Diagram.razor
+++ b/Yijing.web/Pages/Diagram.razor
@@ -1,0 +1,505 @@
+@page "/diagram"
+@using ValueSequencer
+
+<PageTitle>Diagram</PageTitle>
+
+<h1>Diagram</h1>
+
+@if (_hexagram is null)
+{
+    <p>Loading diagram…</p>
+}
+else
+{
+    <div class="diagram-page">
+        <section class="diagram-controls">
+            <div class="control">
+                <label for="sequenceSelect">Hexagram sequence</label>
+                <select id="sequenceSelect" value="@_selectedSequence" @onchange="OnSequenceChanged">
+                    @foreach (var option in _sequenceOptions)
+                    {
+                        <option value="@option.Value">@option.Text</option>
+                    }
+                </select>
+            </div>
+            <div class="control">
+                <label for="labelSelect">Hexagram label</label>
+                <select id="labelSelect" value="@_selectedLabel" @onchange="OnLabelChanged">
+                    @foreach (var option in _labelOptions)
+                    {
+                        <option value="@option.Value">@option.Text</option>
+                    }
+                </select>
+            </div>
+            <div class="control">
+                <label for="lsbSelect">Diagram orientation</label>
+                <select id="lsbSelect" value="@_selectedLsb" @onchange="OnLsbChanged">
+                    @foreach (var option in _lsbOptions)
+                    {
+                        <option value="@option.Value">@option.Text</option>
+                    }
+                </select>
+            </div>
+            <div class="control">
+                <label for="textSelect">Text source</label>
+                <select id="textSelect" value="@_selectedTextSource" @onchange="OnTextChanged">
+                    @foreach (var option in _textOptions)
+                    {
+                        <option value="@option.Value">@option.Text</option>
+                    }
+                </select>
+            </div>
+        </section>
+
+        <section class="diagram-content">
+            <div class="diagram-visual">
+                <header class="diagram-header">
+                    <h2>@_primaryDescription</h2>
+                    @if (!string.IsNullOrWhiteSpace(_secondaryDescription))
+                    {
+                        <p class="secondary">Changing to @(_secondaryDescription)</p>
+                    }
+                    <p class="meta">Sequence @(_hexagram.SequenceStr) · Value @(_hexagram.ValueStr)</p>
+                </header>
+
+                <div class="hexagram-lines">
+                    @foreach (var line in _lines)
+                    {
+                        <div class="hex-line @(line.IsYang ? "yang" : "yin") @(line.IsMoving ? "moving" : string.Empty)">
+                            <span class="line-index">Line @line.Index</span>
+                            <div class="segments">
+                                <div class="segment"></div>
+                                @if (!line.IsYang)
+                                {
+                                    <div class="gap"></div>
+                                }
+                                <div class="segment"></div>
+                            </div>
+                            <span class="line-label">@line.Label</span>
+                        </div>
+                    }
+                </div>
+
+                <div class="diagram-actions">
+                    <button type="button" @onclick="SetFirst">First</button>
+                    <button type="button" @onclick="SetPrevious">Previous</button>
+                    <button type="button" @onclick="SetNext">Next</button>
+                    <button type="button" @onclick="SetLast">Last</button>
+                    <button type="button" class="primary" @onclick="CastHexagram">Cast</button>
+                    <button type="button" @onclick="SetHome" disabled="@(_castHexagram is null)">Home</button>
+                </div>
+
+                <div class="diagram-actions">
+                    <button type="button" @onclick="SetInverse">Inverse</button>
+                    <button type="button" @onclick="SetOpposite">Opposite</button>
+                    <button type="button" @onclick="SetTransverse">Transverse</button>
+                    <button type="button" @onclick="SetNuclear">Nuclear</button>
+                    <button type="button" @onclick="ToggleMove" disabled="@(!_hexagram.IsMoving && _primaryBeforeMove is null)">Toggle Move</button>
+                </div>
+
+                <section class="variation-summary">
+                    <h3>Related hexagrams</h3>
+                    <ul>
+                        <li><strong>Inverse:</strong> @DescribeVariation(h => h.Inverse())</li>
+                        <li><strong>Opposite:</strong> @DescribeVariation(h => h.Opposite())</li>
+                        <li><strong>Transverse:</strong> @DescribeVariation(h => h.Transverse())</li>
+                        <li><strong>Nuclear:</strong> @DescribeVariation(h => h.Nuclear())</li>
+                        <li><strong>Moved:</strong> @DescribeVariation(h => h.Move())</li>
+                    </ul>
+                </section>
+            </div>
+
+            <aside class="diagram-details">
+                <section>
+                    <h3>@SelectedTextLabel</h3>
+                    <article class="hexagram-text">@HexagramText</article>
+                </section>
+
+                <section class="trigram-info">
+                    <h3>Trigrams</h3>
+                    <dl>
+                        <dt>@_upperTrigram.Name</dt>
+                        <dd>@_upperTrigram.Label (@_upperTrigram.SequenceStr)</dd>
+                        <dt>@_lowerTrigram.Name</dt>
+                        <dd>@_lowerTrigram.Label (@_lowerTrigram.SequenceStr)</dd>
+                    </dl>
+                </section>
+            </aside>
+        </section>
+    </div>
+}
+
+@code {
+    private CHexagramValueSequencer? _hexagram;
+    private CHexagramValueSequencer? _castHexagram;
+    private CHexagramValueSequencer? _primaryBeforeMove;
+    private readonly CHexagramSequences _hexagramSequences = new();
+
+    private IReadOnlyList<LineViewModel> _lines = Array.Empty<LineViewModel>();
+    private string _primaryDescription = string.Empty;
+    private string? _secondaryDescription;
+    private MarkupString HexagramText => new MarkupString(_hexagramText ?? string.Empty);
+    private string? _hexagramText;
+
+    private DiagramSettingOption[] _sequenceOptions = Array.Empty<DiagramSettingOption>();
+    private DiagramSettingOption[] _labelOptions = Array.Empty<DiagramSettingOption>();
+    private DiagramSettingOption[] _textOptions = Array.Empty<DiagramSettingOption>();
+    private DiagramSettingOption[] _lsbOptions = Array.Empty<DiagramSettingOption>();
+
+    private int _selectedSequence;
+    private int _selectedLabel;
+    private int _selectedTextSource;
+    private int _selectedLsb;
+
+    private TrigramInfo _upperTrigram = TrigramInfo.Empty("Upper");
+    private TrigramInfo _lowerTrigram = TrigramInfo.Empty("Lower");
+
+    protected override void OnInitialized()
+    {
+        Sequences.Initialise();
+        _hexagram = new CHexagramValueSequencer(1);
+        _hexagram.First();
+
+        _sequenceOptions = BuildOptions("Hexagram Sequence");
+        _labelOptions = BuildOptions("Hexagram Label");
+        _textOptions = BuildOptions("Hexagram Text");
+        _lsbOptions = BuildOptions("Diagram LSB");
+
+        if (_textOptions.Length == 0)
+        {
+            _textOptions = new[] { new DiagramSettingOption(0, "Legge") };
+        }
+
+        _selectedSequence = ClampSelection(Sequences.HexagramSequence, _sequenceOptions.Length);
+        _selectedLabel = ClampSelection(Sequences.HexagramLabel, _labelOptions.Length);
+        _selectedTextSource = ClampSelection(Sequences.HexagramText, _textOptions.Length);
+        _selectedLsb = ClampSelection(Sequences.DiagramLsb, _lsbOptions.Length);
+
+        UpdateFromSequencer();
+    }
+
+    private static int ClampSelection(int value, int length) => length == 0 ? 0 : Math.Clamp(value, 0, length - 1);
+
+    private void UpdateFromSequencer()
+    {
+        if (_hexagram is null)
+        {
+            return;
+        }
+
+        var lines = new List<LineViewModel>();
+        for (int i = 0; i < 6; i++)
+        {
+            var line = _hexagram.Trigram(i / 3).Line(i % 3);
+            bool isYang = line.Value % 2 == 1;
+            bool isMoving = line.Value == 0 || line.Value == 3;
+            lines.Add(new LineViewModel(Index: i + 1, IsYang: isYang, IsMoving: isMoving, Label: line.Label));
+        }
+        _lines = lines
+            .OrderByDescending(l => l.Index)
+            .ToArray();
+
+        _primaryDescription = _hexagram.DescribePrimary(true);
+        _secondaryDescription = _hexagram.DescribeSecondary(true);
+        _upperTrigram = TrigramInfo.From("Upper", _hexagram.Trigram(1));
+        _lowerTrigram = TrigramInfo.From("Lower", _hexagram.Trigram(0));
+        _hexagramText = GetHexagramText();
+        StateHasChanged();
+    }
+
+    private string GetHexagramText()
+    {
+        if (_hexagram is null)
+        {
+            return string.Empty;
+        }
+
+        return _selectedTextSource switch
+        {
+            0 => Legge.Text(_hexagram.Value),
+            1 => Wilhelm.Text(_hexagram.Value),
+            _ => Legge.Text(_hexagram.Value)
+        };
+    }
+
+    private string SelectedTextLabel => _textOptions.FirstOrDefault(o => o.Value == _selectedTextSource).Text ?? "Text";
+
+    private Task OnSequenceChanged(ChangeEventArgs args)
+    {
+        if (_hexagram is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        if (TryParseSelection(args.Value, out var value) && value != _selectedSequence)
+        {
+            _selectedSequence = value;
+            Sequences.HexagramSequence = value;
+            CHexagramValueSequencer.SetCurrentSequence(value);
+            _hexagram.Update();
+            UpdateFromSequencer();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private Task OnLabelChanged(ChangeEventArgs args)
+    {
+        if (_hexagram is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        if (TryParseSelection(args.Value, out var value) && value != _selectedLabel)
+        {
+            _selectedLabel = value;
+            Sequences.HexagramLabel = value;
+            CHexagramValueSequencer.SetCurrentLabel(value);
+            UpdateFromSequencer();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private Task OnTextChanged(ChangeEventArgs args)
+    {
+        if (_hexagram is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        if (TryParseSelection(args.Value, out var value) && value != _selectedTextSource)
+        {
+            _selectedTextSource = value;
+            Sequences.HexagramText = value;
+            UpdateFromSequencer();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private Task OnLsbChanged(ChangeEventArgs args)
+    {
+        if (_hexagram is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        if (TryParseSelection(args.Value, out var value) && value != _selectedLsb)
+        {
+            _selectedLsb = value;
+            Sequences.DiagramLsb = value;
+            Sequences.SetLSB(Sequences.DiagramLsb == 0);
+            _hexagram.Update();
+            UpdateFromSequencer();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static bool TryParseSelection(object? value, out int parsed)
+    {
+        if (value is null)
+        {
+            parsed = 0;
+            return false;
+        }
+
+        if (value is int intValue)
+        {
+            parsed = intValue;
+            return true;
+        }
+
+        return int.TryParse(value.ToString(), out parsed);
+    }
+
+    private void SetFirst()
+    {
+        if (_hexagram is null)
+        {
+            return;
+        }
+
+        _hexagram.First();
+        _castHexagram = null;
+        _primaryBeforeMove = null;
+        UpdateFromSequencer();
+    }
+
+    private void SetPrevious()
+    {
+        if (_hexagram is null)
+        {
+            return;
+        }
+
+        _hexagram.Previous();
+        _primaryBeforeMove = null;
+        UpdateFromSequencer();
+    }
+
+    private void SetNext()
+    {
+        if (_hexagram is null)
+        {
+            return;
+        }
+
+        _hexagram.Next();
+        _primaryBeforeMove = null;
+        UpdateFromSequencer();
+    }
+
+    private void SetLast()
+    {
+        if (_hexagram is null)
+        {
+            return;
+        }
+
+        _hexagram.Last();
+        _primaryBeforeMove = null;
+        UpdateFromSequencer();
+    }
+
+    private void CastHexagram()
+    {
+        if (_hexagram is null)
+        {
+            return;
+        }
+
+        _hexagramSequences.AutoCast(ref _hexagram);
+        _hexagram.Update();
+        _castHexagram = new CHexagramValueSequencer(ref _hexagram);
+        _primaryBeforeMove = null;
+        UpdateFromSequencer();
+    }
+
+    private void SetHome()
+    {
+        if (_castHexagram is null)
+        {
+            return;
+        }
+
+        _hexagram = new CHexagramValueSequencer(ref _castHexagram);
+        _primaryBeforeMove = null;
+        UpdateFromSequencer();
+    }
+
+    private void SetInverse()
+    {
+        if (_hexagram is null)
+        {
+            return;
+        }
+
+        _hexagram.Inverse();
+        _primaryBeforeMove = null;
+        UpdateFromSequencer();
+    }
+
+    private void SetOpposite()
+    {
+        if (_hexagram is null)
+        {
+            return;
+        }
+
+        _hexagram.Opposite();
+        _primaryBeforeMove = null;
+        UpdateFromSequencer();
+    }
+
+    private void SetTransverse()
+    {
+        if (_hexagram is null)
+        {
+            return;
+        }
+
+        _hexagram.Transverse();
+        _primaryBeforeMove = null;
+        UpdateFromSequencer();
+    }
+
+    private void SetNuclear()
+    {
+        if (_hexagram is null)
+        {
+            return;
+        }
+
+        _hexagram.Nuclear();
+        _primaryBeforeMove = null;
+        UpdateFromSequencer();
+    }
+
+    private void ToggleMove()
+    {
+        if (_hexagram is null)
+        {
+            return;
+        }
+
+        if (_hexagram.IsMoving)
+        {
+            _primaryBeforeMove = new CHexagramValueSequencer(ref _hexagram);
+            _hexagram.Move();
+        }
+        else if (_primaryBeforeMove is not null)
+        {
+            _hexagram = new CHexagramValueSequencer(ref _primaryBeforeMove);
+            _primaryBeforeMove = null;
+        }
+
+        UpdateFromSequencer();
+    }
+
+    private string DescribeVariation(Func<CHexagramValueSequencer, CValueSequencer> transform)
+    {
+        if (_hexagram is null)
+        {
+            return "–";
+        }
+
+        var copy = new CHexagramValueSequencer(ref _hexagram);
+        transform(copy);
+        return copy.DescribePrimary(true);
+    }
+
+    private static DiagramSettingOption[] BuildOptions(string name)
+    {
+        var options = new List<DiagramSettingOption>();
+        int index = 0;
+        while (true)
+        {
+            string value = Sequences.DiagramSetting(name, index);
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                break;
+            }
+
+            options.Add(new DiagramSettingOption(index, value));
+            index++;
+        }
+
+        return options.ToArray();
+    }
+
+    private readonly record struct LineViewModel(int Index, bool IsYang, bool IsMoving, string Label);
+
+    private readonly record struct DiagramSettingOption(int Value, string Text);
+
+    private readonly record struct TrigramInfo(string Name, string Label, string SequenceStr)
+    {
+        public static TrigramInfo Empty(string name) => new(name, string.Empty, string.Empty);
+
+        public static TrigramInfo From(string name, CTrigramValueSequencer trigram)
+        {
+            return new TrigramInfo(name, trigram.Label, trigram.SequenceStr);
+        }
+    }
+}

--- a/Yijing.web/Pages/Diagram.razor
+++ b/Yijing.web/Pages/Diagram.razor
@@ -13,101 +13,103 @@ else
 {
     <div class="diagram-page">
         <section class="diagram-content">
-            <section class="diagram-controls">
-                <div class="control">
-                    <label for="sequenceSelect">Hexagram sequence</label>
-                    <select id="sequenceSelect" value="@_selectedSequence" @onchange="OnSequenceChanged">
-                        @foreach (var option in _sequenceOptions)
+            <div class="diagram-primary">
+                <div class="diagram-visual">
+                    <header class="diagram-header">
+                        <h2>@_primaryDescription</h2>
+                        @if (!string.IsNullOrWhiteSpace(_secondaryDescription))
                         {
-                            <option value="@option.Value">@option.Text</option>
+                            <p class="secondary">Changing to @(_secondaryDescription)</p>
                         }
-                    </select>
-                </div>
-                <div class="control">
-                    <label for="labelSelect">Hexagram label</label>
-                    <select id="labelSelect" value="@_selectedLabel" @onchange="OnLabelChanged">
-                        @foreach (var option in _labelOptions)
-                        {
-                            <option value="@option.Value">@option.Text</option>
-                        }
-                    </select>
-                </div>
-                <div class="control">
-                    <label for="lsbSelect">Diagram orientation</label>
-                    <select id="lsbSelect" value="@_selectedLsb" @onchange="OnLsbChanged">
-                        @foreach (var option in _lsbOptions)
-                        {
-                            <option value="@option.Value">@option.Text</option>
-                        }
-                    </select>
-                </div>
-                <div class="control">
-                    <label for="textSelect">Text source</label>
-                    <select id="textSelect" value="@_selectedTextSource" @onchange="OnTextChanged">
-                        @foreach (var option in _textOptions)
-                        {
-                            <option value="@option.Value">@option.Text</option>
-                        }
-                    </select>
-                </div>
-            </section>
+                        <p class="meta">Sequence @(_hexagram.SequenceStr) · Value @(_hexagram.ValueStr)</p>
+                    </header>
 
-            <div class="diagram-visual">
-                <header class="diagram-header">
-                    <h2>@_primaryDescription</h2>
-                    @if (!string.IsNullOrWhiteSpace(_secondaryDescription))
-                    {
-                        <p class="secondary">Changing to @(_secondaryDescription)</p>
-                    }
-                    <p class="meta">Sequence @(_hexagram.SequenceStr) · Value @(_hexagram.ValueStr)</p>
-                </header>
-
-                <div class="hexagram-lines">
-                    @foreach (var line in _lines)
-                    {
-                        <div class="hex-line @(line.IsYang ? "yang" : "yin") @(line.IsMoving ? "moving" : string.Empty)">
-                            <div class="segments">
-                                @if (line.IsYang)
-                                {
-                                    <div class="segment full"></div>
-                                }
-                                else
-                                {
-                                    <div class="segment"></div>
-                                    <div class="gap"></div>
-                                    <div class="segment"></div>
-                                }
+                    <div class="hexagram-lines">
+                        @foreach (var line in _lines)
+                        {
+                            <div class="hex-line @(line.IsYang ? "yang" : "yin") @(line.IsMoving ? "moving" : string.Empty)">
+                                <div class="segments">
+                                    @if (line.IsYang)
+                                    {
+                                        <div class="segment full"></div>
+                                    }
+                                    else
+                                    {
+                                        <div class="segment"></div>
+                                        <div class="gap"></div>
+                                        <div class="segment"></div>
+                                    }
+                                </div>
                             </div>
-                        </div>
-                    }
+                        }
+                    </div>
+
+                    <div class="diagram-actions">
+                        <button type="button" @onclick="SetFirst">First</button>
+                        <button type="button" @onclick="SetPrevious">Previous</button>
+                        <button type="button" @onclick="SetNext">Next</button>
+                        <button type="button" @onclick="SetLast">Last</button>
+                        <button type="button" class="primary" @onclick="CastHexagram">Cast</button>
+                        <button type="button" @onclick="SetHome" disabled="@(_castHexagram is null)">Home</button>
+                    </div>
+
+                    <div class="diagram-actions">
+                        <button type="button" @onclick="SetInverse">Inverse</button>
+                        <button type="button" @onclick="SetOpposite">Opposite</button>
+                        <button type="button" @onclick="SetTransverse">Transverse</button>
+                        <button type="button" @onclick="SetNuclear">Nuclear</button>
+                        <button type="button" @onclick="ToggleMove" disabled="@(!_hexagram.IsMoving && _primaryBeforeMove is null)">Toggle Move</button>
+                    </div>
+
+                    <section class="variation-summary">
+                        <h3>Related hexagrams</h3>
+                        <ul>
+                            <li><strong>Inverse:</strong> @DescribeVariation(h => h.Inverse())</li>
+                            <li><strong>Opposite:</strong> @DescribeVariation(h => h.Opposite())</li>
+                            <li><strong>Transverse:</strong> @DescribeVariation(h => h.Transverse())</li>
+                            <li><strong>Nuclear:</strong> @DescribeVariation(h => h.Nuclear())</li>
+                            <li><strong>Moved:</strong> @DescribeVariation(h => h.Move())</li>
+                        </ul>
+                    </section>
                 </div>
 
-                <div class="diagram-actions">
-                    <button type="button" @onclick="SetFirst">First</button>
-                    <button type="button" @onclick="SetPrevious">Previous</button>
-                    <button type="button" @onclick="SetNext">Next</button>
-                    <button type="button" @onclick="SetLast">Last</button>
-                    <button type="button" class="primary" @onclick="CastHexagram">Cast</button>
-                    <button type="button" @onclick="SetHome" disabled="@(_castHexagram is null)">Home</button>
-                </div>
-
-                <div class="diagram-actions">
-                    <button type="button" @onclick="SetInverse">Inverse</button>
-                    <button type="button" @onclick="SetOpposite">Opposite</button>
-                    <button type="button" @onclick="SetTransverse">Transverse</button>
-                    <button type="button" @onclick="SetNuclear">Nuclear</button>
-                    <button type="button" @onclick="ToggleMove" disabled="@(!_hexagram.IsMoving && _primaryBeforeMove is null)">Toggle Move</button>
-                </div>
-
-                <section class="variation-summary">
-                    <h3>Related hexagrams</h3>
-                    <ul>
-                        <li><strong>Inverse:</strong> @DescribeVariation(h => h.Inverse())</li>
-                        <li><strong>Opposite:</strong> @DescribeVariation(h => h.Opposite())</li>
-                        <li><strong>Transverse:</strong> @DescribeVariation(h => h.Transverse())</li>
-                        <li><strong>Nuclear:</strong> @DescribeVariation(h => h.Nuclear())</li>
-                        <li><strong>Moved:</strong> @DescribeVariation(h => h.Move())</li>
-                    </ul>
+                <section class="diagram-controls">
+                    <div class="control">
+                        <label for="sequenceSelect">Hexagram sequence</label>
+                        <select id="sequenceSelect" value="@_selectedSequence" @onchange="OnSequenceChanged">
+                            @foreach (var option in _sequenceOptions)
+                            {
+                                <option value="@option.Value">@option.Text</option>
+                            }
+                        </select>
+                    </div>
+                    <div class="control">
+                        <label for="labelSelect">Hexagram label</label>
+                        <select id="labelSelect" value="@_selectedLabel" @onchange="OnLabelChanged">
+                            @foreach (var option in _labelOptions)
+                            {
+                                <option value="@option.Value">@option.Text</option>
+                            }
+                        </select>
+                    </div>
+                    <div class="control">
+                        <label for="lsbSelect">Diagram orientation</label>
+                        <select id="lsbSelect" value="@_selectedLsb" @onchange="OnLsbChanged">
+                            @foreach (var option in _lsbOptions)
+                            {
+                                <option value="@option.Value">@option.Text</option>
+                            }
+                        </select>
+                    </div>
+                    <div class="control">
+                        <label for="textSelect">Text source</label>
+                        <select id="textSelect" value="@_selectedTextSource" @onchange="OnTextChanged">
+                            @foreach (var option in _textOptions)
+                            {
+                                <option value="@option.Value">@option.Text</option>
+                            }
+                        </select>
+                    </div>
                 </section>
             </div>
 

--- a/Yijing.web/Pages/Diagram.razor
+++ b/Yijing.web/Pages/Diagram.razor
@@ -472,21 +472,33 @@ else
 
     private static DiagramSettingOption[] BuildOptions(string name)
     {
-        var options = new List<DiagramSettingOption>();
-        int index = 0;
-        while (true)
+        var settings = Sequences.strDiagramSettings;
+        int rowCount = settings.GetLength(0);
+        int columnCount = settings.GetLength(1);
+
+        for (int row = 0; row < rowCount; row++)
         {
-            string value = Sequences.DiagramSetting(name, index);
-            if (string.IsNullOrWhiteSpace(value))
+            if (settings[row, 0] != name)
             {
-                break;
+                continue;
             }
 
-            options.Add(new DiagramSettingOption(index, value));
-            index++;
+            var options = new List<DiagramSettingOption>();
+            for (int column = 1; column < columnCount; column++)
+            {
+                var value = settings[row, column];
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    break;
+                }
+
+                options.Add(new DiagramSettingOption(column - 1, value));
+            }
+
+            return options.ToArray();
         }
 
-        return options.ToArray();
+        return Array.Empty<DiagramSettingOption>();
     }
 
     private readonly record struct LineViewModel(int Index, bool IsYang, bool IsMoving, string Label);

--- a/Yijing.web/Pages/Diagram.razor
+++ b/Yijing.web/Pages/Diagram.razor
@@ -12,46 +12,46 @@
 else
 {
     <div class="diagram-page">
-        <section class="diagram-controls">
-            <div class="control">
-                <label for="sequenceSelect">Hexagram sequence</label>
-                <select id="sequenceSelect" value="@_selectedSequence" @onchange="OnSequenceChanged">
-                    @foreach (var option in _sequenceOptions)
-                    {
-                        <option value="@option.Value">@option.Text</option>
-                    }
-                </select>
-            </div>
-            <div class="control">
-                <label for="labelSelect">Hexagram label</label>
-                <select id="labelSelect" value="@_selectedLabel" @onchange="OnLabelChanged">
-                    @foreach (var option in _labelOptions)
-                    {
-                        <option value="@option.Value">@option.Text</option>
-                    }
-                </select>
-            </div>
-            <div class="control">
-                <label for="lsbSelect">Diagram orientation</label>
-                <select id="lsbSelect" value="@_selectedLsb" @onchange="OnLsbChanged">
-                    @foreach (var option in _lsbOptions)
-                    {
-                        <option value="@option.Value">@option.Text</option>
-                    }
-                </select>
-            </div>
-            <div class="control">
-                <label for="textSelect">Text source</label>
-                <select id="textSelect" value="@_selectedTextSource" @onchange="OnTextChanged">
-                    @foreach (var option in _textOptions)
-                    {
-                        <option value="@option.Value">@option.Text</option>
-                    }
-                </select>
-            </div>
-        </section>
-
         <section class="diagram-content">
+            <section class="diagram-controls">
+                <div class="control">
+                    <label for="sequenceSelect">Hexagram sequence</label>
+                    <select id="sequenceSelect" value="@_selectedSequence" @onchange="OnSequenceChanged">
+                        @foreach (var option in _sequenceOptions)
+                        {
+                            <option value="@option.Value">@option.Text</option>
+                        }
+                    </select>
+                </div>
+                <div class="control">
+                    <label for="labelSelect">Hexagram label</label>
+                    <select id="labelSelect" value="@_selectedLabel" @onchange="OnLabelChanged">
+                        @foreach (var option in _labelOptions)
+                        {
+                            <option value="@option.Value">@option.Text</option>
+                        }
+                    </select>
+                </div>
+                <div class="control">
+                    <label for="lsbSelect">Diagram orientation</label>
+                    <select id="lsbSelect" value="@_selectedLsb" @onchange="OnLsbChanged">
+                        @foreach (var option in _lsbOptions)
+                        {
+                            <option value="@option.Value">@option.Text</option>
+                        }
+                    </select>
+                </div>
+                <div class="control">
+                    <label for="textSelect">Text source</label>
+                    <select id="textSelect" value="@_selectedTextSource" @onchange="OnTextChanged">
+                        @foreach (var option in _textOptions)
+                        {
+                            <option value="@option.Value">@option.Text</option>
+                        }
+                    </select>
+                </div>
+            </section>
+
             <div class="diagram-visual">
                 <header class="diagram-header">
                     <h2>@_primaryDescription</h2>
@@ -66,7 +66,6 @@ else
                     @foreach (var line in _lines)
                     {
                         <div class="hex-line @(line.IsYang ? "yang" : "yin") @(line.IsMoving ? "moving" : string.Empty)">
-                            <span class="line-index">Line @line.Index</span>
                             <div class="segments">
                                 @if (line.IsYang)
                                 {
@@ -79,7 +78,6 @@ else
                                     <div class="segment"></div>
                                 }
                             </div>
-                            <span class="line-label">@line.Label</span>
                         </div>
                     }
                 </div>
@@ -197,7 +195,7 @@ else
             var line = _hexagram.Trigram(i / 3).Line(i % 3);
             bool isYang = line.Value % 2 == 1;
             bool isMoving = line.Value == 0 || line.Value == 3;
-            lines.Add(new LineViewModel(Index: i + 1, IsYang: isYang, IsMoving: isMoving, Label: line.Label));
+            lines.Add(new LineViewModel(Index: i + 1, IsYang: isYang, IsMoving: isMoving));
         }
         _lines = lines
             .OrderByDescending(l => l.Index)
@@ -505,7 +503,7 @@ else
         return Array.Empty<DiagramSettingOption>();
     }
 
-    private readonly record struct LineViewModel(int Index, bool IsYang, bool IsMoving, string Label);
+    private readonly record struct LineViewModel(int Index, bool IsYang, bool IsMoving);
 
     private readonly record struct DiagramSettingOption(int Value, string Text);
 

--- a/Yijing.web/Pages/Index.razor
+++ b/Yijing.web/Pages/Index.razor
@@ -1,0 +1,13 @@
+@page "/"
+
+<PageTitle>Home</PageTitle>
+
+<h1>Yijing Diagram Explorer</h1>
+
+<p>
+    Explore the structure of the hexagrams from the Classic of Change in the Diagram page.
+</p>
+
+<p>
+    Use the navigation menu to open the diagram visualisation.
+</p>

--- a/Yijing.web/Pages/_Host.cshtml
+++ b/Yijing.web/Pages/_Host.cshtml
@@ -1,0 +1,19 @@
+@page "/"
+@namespace Yijing.web.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Yijing Diagram</title>
+    <base href="~/" />
+    <link rel="stylesheet" href="css/app.css" />
+</head>
+<body>
+    <app>
+        <component type="typeof(App)" render-mode="ServerPrerendered" />
+    </app>
+    <script src="_framework/blazor.server.js"></script>
+</body>
+</html>

--- a/Yijing.web/Pages/_Imports.razor
+++ b/Yijing.web/Pages/_Imports.razor
@@ -1,0 +1,4 @@
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web
+@using Yijing.web
+@using Yijing.web.Shared

--- a/Yijing.web/Program.cs
+++ b/Yijing.web/Program.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorPages();
+builder.Services.AddServerSideBlazor();
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+}
+
+app.UseStaticFiles();
+
+app.UseRouting();
+
+app.MapBlazorHub();
+app.MapFallbackToPage("/_Host");
+
+app.Run();

--- a/Yijing.web/Properties/launchSettings.json
+++ b/Yijing.web/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "Yijing.web": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7241;http://localhost:5241",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/Yijing.web/Shared/MainLayout.razor
+++ b/Yijing.web/Shared/MainLayout.razor
@@ -1,0 +1,17 @@
+@inherits LayoutComponentBase
+
+<div class="page">
+    <div class="sidebar">
+        <NavMenu />
+    </div>
+
+    <main>
+        <div class="top-row px-4">
+            <a href="https://github.com/stephenvivash" target="_blank" rel="noopener">Yijing Project</a>
+        </div>
+
+        <article class="content px-4">
+            @Body
+        </article>
+    </main>
+</div>

--- a/Yijing.web/Shared/NavMenu.razor
+++ b/Yijing.web/Shared/NavMenu.razor
@@ -1,0 +1,20 @@
+<nav class="nav-menu">
+    <div class="nav-brand">
+        <h2>Yijing</h2>
+        <p>The classic of change</p>
+    </div>
+    <ul>
+        <li>
+            <NavLink class="nav-link" href="/" Match="NavLinkMatch.All">
+                <span class="oi" aria-hidden="true">🏠</span>
+                <span>Home</span>
+            </NavLink>
+        </li>
+        <li>
+            <NavLink class="nav-link" href="/diagram">
+                <span class="oi" aria-hidden="true">📜</span>
+                <span>Diagram</span>
+            </NavLink>
+        </li>
+    </ul>
+</nav>

--- a/Yijing.web/Shared/NavMenu.razor.css
+++ b/Yijing.web/Shared/NavMenu.razor.css
@@ -1,0 +1,54 @@
+.nav-menu {
+    padding: 1.5rem 1rem;
+    background-color: #1f2933;
+    color: #f7fafc;
+    min-height: 100vh;
+    width: 15rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.nav-brand h2 {
+    margin: 0;
+    font-size: 1.75rem;
+}
+
+.nav-brand p {
+    margin: 0.25rem 0 0;
+    font-size: 0.9rem;
+    color: #cbd5f5;
+}
+
+.nav-menu ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.nav-link {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.6rem 0.8rem;
+    border-radius: 0.5rem;
+    color: inherit;
+    text-decoration: none;
+    font-weight: 600;
+    transition: background-color 0.2s ease-in-out;
+}
+
+.nav-link:hover {
+    background-color: rgba(255, 255, 255, 0.12);
+}
+
+.nav-link.active {
+    background-color: rgba(255, 255, 255, 0.24);
+}
+
+.nav-link span:first-child {
+    font-size: 1.2rem;
+}

--- a/Yijing.web/Yijing.web.csproj
+++ b/Yijing.web/Yijing.web.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ValueSequencer\ValueSequencer.csproj" />
+  </ItemGroup>
+</Project>

--- a/Yijing.web/_Imports.razor
+++ b/Yijing.web/_Imports.razor
@@ -1,0 +1,9 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.JSInterop
+@using Yijing.web
+@using Yijing.web.Shared

--- a/Yijing.web/appsettings.json
+++ b/Yijing.web/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/Yijing.web/wwwroot/css/app.css
+++ b/Yijing.web/wwwroot/css/app.css
@@ -112,6 +112,8 @@ h1, h2, h3 {
     flex-direction: column;
     gap: 0.5rem;
     margin: 1.5rem 0;
+    --line-length: 220px;
+    --yin-gap: 18px;
 }
 
 .hex-line {
@@ -131,31 +133,27 @@ h1, h2, h3 {
     display: flex;
     align-items: center;
     gap: 0;
-}
-
-.hex-line.yang .segments {
-    gap: 0;
+    width: var(--line-length);
 }
 
 .hex-line .segment {
     height: 21px;
-    width: 110px;
     border-radius: 12px;
     background: linear-gradient(90deg, #111827, #1f2937);
 }
 
 .hex-line .segment.full {
-    width: 220px;
+    width: 100%;
 }
 
 .hex-line .gap {
     height: 21px;
-    width: 18px;
+    width: var(--yin-gap);
     background-color: transparent;
 }
 
 .hex-line.yin .segment {
-    width: 90px;
+    width: calc((var(--line-length) - var(--yin-gap)) / 2);
 }
 
 .hex-line.yin .segment:first-child {

--- a/Yijing.web/wwwroot/css/app.css
+++ b/Yijing.web/wwwroot/css/app.css
@@ -133,6 +133,10 @@ h1, h2, h3 {
     gap: 0.4rem;
 }
 
+.hex-line.yang .segments {
+    gap: 0;
+}
+
 .hex-line .segment {
     height: 14px;
     width: 110px;
@@ -237,6 +241,105 @@ h1, h2, h3 {
 .trigram-info dd {
     margin: 0;
     color: #475569;
+}
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #0f172a;
+        color: #e2e8f0;
+    }
+
+    main {
+        background-color: #111827;
+    }
+
+    .top-row {
+        background-color: #1f2937;
+        border-bottom: 1px solid #334155;
+    }
+
+    .top-row a {
+        color: #e2e8f0;
+    }
+
+    h1,
+    h2,
+    h3 {
+        color: #f8fafc;
+    }
+
+    .diagram-controls {
+        background: linear-gradient(135deg, rgba(96, 165, 250, 0.2), rgba(59, 130, 246, 0.1));
+        border: 1px solid rgba(147, 197, 253, 0.25);
+    }
+
+    .diagram-controls label {
+        color: #e2e8f0;
+    }
+
+    .diagram-controls select {
+        background-color: #1f2937;
+        color: #e2e8f0;
+        border-color: #334155;
+    }
+
+    .diagram-content {
+        color: #e2e8f0;
+    }
+
+    .diagram-visual,
+    .diagram-details {
+        background-color: #1f2937;
+        box-shadow: 0 20px 40px rgba(2, 6, 23, 0.55);
+    }
+
+    .diagram-header .meta {
+        color: #94a3b8;
+    }
+
+    .diagram-header .secondary {
+        color: #60a5fa;
+    }
+
+    .hex-line .line-index,
+    .hex-line .line-label {
+        color: #cbd5f5;
+    }
+
+    .hex-line .segment {
+        background: linear-gradient(90deg, #f1f5f9, #cbd5f5);
+    }
+
+    .hex-line.moving .segment {
+        background: linear-gradient(90deg, #fb7185, #fb923c);
+        box-shadow: 0 0 16px rgba(251, 146, 60, 0.5);
+    }
+
+    .diagram-actions button {
+        background-color: #334155;
+        color: #e2e8f0;
+    }
+
+    .diagram-actions button.primary {
+        background: linear-gradient(135deg, #2563eb, #3b82f6);
+        box-shadow: 0 12px 25px rgba(30, 64, 175, 0.35);
+    }
+
+    .diagram-actions button:hover:not(:disabled) {
+        box-shadow: 0 10px 18px rgba(30, 64, 175, 0.35);
+    }
+
+    .variation-summary ul {
+        color: #cbd5f5;
+    }
+
+    .trigram-info dt {
+        color: #e2e8f0;
+    }
+
+    .trigram-info dd {
+        color: #cbd5f5;
+    }
 }
 
 @media (max-width: 992px) {

--- a/Yijing.web/wwwroot/css/app.css
+++ b/Yijing.web/wwwroot/css/app.css
@@ -110,7 +110,7 @@ h1, h2, h3 {
 .hexagram-lines {
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 0.5rem;
     margin: 1.5rem 0;
 }
 
@@ -130,7 +130,7 @@ h1, h2, h3 {
 .hex-line .segments {
     display: flex;
     align-items: center;
-    gap: 0.4rem;
+    gap: 0;
 }
 
 .hex-line.yang .segments {
@@ -138,20 +138,34 @@ h1, h2, h3 {
 }
 
 .hex-line .segment {
-    height: 14px;
+    height: 21px;
     width: 110px;
-    border-radius: 10px;
+    border-radius: 12px;
     background: linear-gradient(90deg, #111827, #1f2937);
 }
 
+.hex-line .segment.full {
+    width: 220px;
+}
+
 .hex-line .gap {
-    height: 12px;
-    width: 28px;
+    height: 21px;
+    width: 18px;
     background-color: transparent;
 }
 
 .hex-line.yin .segment {
     width: 90px;
+}
+
+.hex-line.yin .segment:first-child {
+    border-top-right-radius: 6px;
+    border-bottom-right-radius: 6px;
+}
+
+.hex-line.yin .segment:last-child {
+    border-top-left-radius: 6px;
+    border-bottom-left-radius: 6px;
 }
 
 .hex-line.moving .segment {

--- a/Yijing.web/wwwroot/css/app.css
+++ b/Yijing.web/wwwroot/css/app.css
@@ -84,9 +84,15 @@ h1, h2, h3 {
 
 .diagram-content {
     display: grid;
-    grid-template-columns: minmax(0, 260px) minmax(0, 2fr) minmax(0, 1fr);
+    grid-template-columns: minmax(0, 360px) minmax(0, 1fr);
     gap: 1.5rem;
     align-items: start;
+}
+
+.diagram-primary {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
 }
 
 .diagram-visual {
@@ -119,7 +125,7 @@ h1, h2, h3 {
 
 .hex-line {
     display: flex;
-    justify-content: center;
+    justify-content: flex-start;
 }
 
 .hex-line .segments {
@@ -127,8 +133,8 @@ h1, h2, h3 {
     align-items: center;
     gap: 0;
     width: var(--line-length);
-    justify-content: center;
-    margin: 0 auto;
+    justify-content: flex-start;
+    margin: 0;
 }
 
 .hex-line .segment {

--- a/Yijing.web/wwwroot/css/app.css
+++ b/Yijing.web/wwwroot/css/app.css
@@ -64,6 +64,7 @@ h1, h2, h3 {
     background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(59, 130, 246, 0.05));
     border-radius: 1rem;
     border: 1px solid rgba(30, 64, 175, 0.15);
+    align-content: start;
 }
 
 .diagram-controls label {
@@ -83,7 +84,7 @@ h1, h2, h3 {
 
 .diagram-content {
     display: grid;
-    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    grid-template-columns: minmax(0, 260px) minmax(0, 2fr) minmax(0, 1fr);
     gap: 1.5rem;
     align-items: start;
 }
@@ -117,16 +118,8 @@ h1, h2, h3 {
 }
 
 .hex-line {
-    display: grid;
-    grid-template-columns: 80px minmax(0, 1fr) 120px;
-    align-items: center;
-    gap: 1rem;
-}
-
-.hex-line .line-index {
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: #334155;
+    display: flex;
+    justify-content: center;
 }
 
 .hex-line .segments {
@@ -134,6 +127,8 @@ h1, h2, h3 {
     align-items: center;
     gap: 0;
     width: var(--line-length);
+    justify-content: center;
+    margin: 0 auto;
 }
 
 .hex-line .segment {
@@ -171,10 +166,6 @@ h1, h2, h3 {
     box-shadow: 0 0 10px rgba(236, 72, 153, 0.5);
 }
 
-.hex-line .line-label {
-    font-size: 0.9rem;
-    color: #475569;
-}
 
 .diagram-actions {
     display: flex;
@@ -313,11 +304,6 @@ h1, h2, h3 {
         color: #60a5fa;
     }
 
-    .hex-line .line-index,
-    .hex-line .line-label {
-        color: #cbd5f5;
-    }
-
     .hex-line .segment {
         background: linear-gradient(90deg, #f1f5f9, #cbd5f5);
     }
@@ -357,6 +343,10 @@ h1, h2, h3 {
 @media (max-width: 992px) {
     .diagram-content {
         grid-template-columns: 1fr;
+    }
+
+    .diagram-controls {
+        grid-template-columns: minmax(0, 1fr);
     }
 
     .nav-menu {

--- a/Yijing.web/wwwroot/css/app.css
+++ b/Yijing.web/wwwroot/css/app.css
@@ -1,0 +1,262 @@
+:root {
+    color-scheme: light dark;
+    font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+}
+
+body {
+    margin: 0;
+    background-color: #f5f5f5;
+    color: #1f2933;
+}
+
+.page {
+    display: flex;
+    min-height: 100vh;
+}
+
+.sidebar {
+    flex: 0 0 auto;
+}
+
+main {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    background-color: #ffffff;
+}
+
+.top-row {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    padding: 1rem;
+    background-color: #edf2f7;
+    border-bottom: 1px solid #d2d6dc;
+}
+
+.top-row a {
+    color: #1f2933;
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.content {
+    flex: 1;
+    padding: 2rem;
+}
+
+h1, h2, h3 {
+    color: #102a43;
+}
+
+.diagram-page {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.diagram-controls {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 1rem;
+    padding: 1rem;
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(59, 130, 246, 0.05));
+    border-radius: 1rem;
+    border: 1px solid rgba(30, 64, 175, 0.15);
+}
+
+.diagram-controls label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 0.35rem;
+}
+
+.diagram-controls select {
+    width: 100%;
+    padding: 0.45rem 0.6rem;
+    border: 1px solid #d2d6dc;
+    border-radius: 0.5rem;
+    background-color: #ffffff;
+    font-size: 0.95rem;
+}
+
+.diagram-content {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    gap: 1.5rem;
+    align-items: start;
+}
+
+.diagram-visual {
+    background-color: #ffffff;
+    border-radius: 1rem;
+    padding: 1.5rem;
+    box-shadow: 0 15px 35px rgba(15, 23, 42, 0.08);
+}
+
+.diagram-header .meta {
+    margin-top: 0.3rem;
+    color: #52606d;
+    font-size: 0.95rem;
+}
+
+.diagram-header .secondary {
+    margin: 0.35rem 0 0;
+    color: #1d4ed8;
+    font-weight: 600;
+}
+
+.hexagram-lines {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin: 1.5rem 0;
+}
+
+.hex-line {
+    display: grid;
+    grid-template-columns: 80px minmax(0, 1fr) 120px;
+    align-items: center;
+    gap: 1rem;
+}
+
+.hex-line .line-index {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #334155;
+}
+
+.hex-line .segments {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.hex-line .segment {
+    height: 14px;
+    width: 110px;
+    border-radius: 10px;
+    background: linear-gradient(90deg, #111827, #1f2937);
+}
+
+.hex-line .gap {
+    height: 12px;
+    width: 28px;
+    background-color: transparent;
+}
+
+.hex-line.yin .segment {
+    width: 90px;
+}
+
+.hex-line.moving .segment {
+    background: linear-gradient(90deg, #ec4899, #f97316);
+    box-shadow: 0 0 10px rgba(236, 72, 153, 0.5);
+}
+
+.hex-line .line-label {
+    font-size: 0.9rem;
+    color: #475569;
+}
+
+.diagram-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    margin-bottom: 1rem;
+}
+
+.diagram-actions button {
+    padding: 0.55rem 0.9rem;
+    border-radius: 0.5rem;
+    border: 1px solid transparent;
+    background-color: #e2e8f0;
+    color: #1f2933;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.diagram-actions button.primary {
+    background: linear-gradient(135deg, #2563eb, #3b82f6);
+    color: #ffffff;
+    box-shadow: 0 10px 20px rgba(37, 99, 235, 0.25);
+}
+
+.diagram-actions button:disabled {
+    opacity: 0.6;
+    cursor: default;
+    box-shadow: none;
+}
+
+.diagram-actions button:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 8px 15px rgba(30, 64, 175, 0.2);
+}
+
+.variation-summary {
+    margin-top: 2rem;
+}
+
+.variation-summary ul {
+    margin: 0;
+    padding-left: 1.1rem;
+    color: #334155;
+}
+
+.diagram-details {
+    background-color: #ffffff;
+    border-radius: 1rem;
+    padding: 1.5rem;
+    box-shadow: 0 15px 35px rgba(15, 23, 42, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.hexagram-text {
+    max-height: 460px;
+    overflow-y: auto;
+    padding-right: 0.5rem;
+    line-height: 1.55;
+}
+
+.trigram-info dl {
+    margin: 0;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.35rem 0.75rem;
+}
+
+.trigram-info dt {
+    font-weight: 700;
+    color: #1f2937;
+}
+
+.trigram-info dd {
+    margin: 0;
+    color: #475569;
+}
+
+@media (max-width: 992px) {
+    .diagram-content {
+        grid-template-columns: 1fr;
+    }
+
+    .nav-menu {
+        min-height: auto;
+        width: 100%;
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+    }
+
+    .nav-menu ul {
+        flex-direction: row;
+    }
+
+    .page {
+        flex-direction: column;
+    }
+}


### PR DESCRIPTION
## Summary
- add the Yijing.web Blazor Server project and wire it into the solution
- implement a Diagram page that visualises and explores hexagrams using the ValueSequencer APIs without AI features
- add layout and styling resources for the new web front end

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d2475c0bd8832bb05fb99780c7b252