### PR TITLE
Add x:DataType for CardColor bindings

### DIFF
--- a/Yijing.maui/Views/DiagramView.xaml
+++ b/Yijing.maui/Views/DiagramView.xaml
@@ -1,20 +1,22 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentView 
-	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-	x:Class="Yijing.Views.DiagramView"
-	x:Name="diaView"
-	Loaded="Page_Loaded"
-	>
+<ContentView
+        xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        xmlns:views="clr-namespace:Yijing.Views"
+        x:Class="Yijing.Views.DiagramView"
+        x:Name="diaView"
+        Loaded="Page_Loaded"
+        >
 
 	<!--BackgroundColor="{Binding CardColor}"
 		BorderColor="{Binding BorderColor}"-->
 
 	<ScrollView>
 
-		<Border 
-			BindingContext="{x:Reference diaView}"
-			BackgroundColor="{Binding CardColor}"
+                <Border
+                        BindingContext="{x:Reference diaView}"
+                        x:DataType="views:DiagramView"
+                        BackgroundColor="{Binding CardColor}"
 			>
 
 			<StackLayout

--- a/Yijing.maui/Views/DiagramView.xaml
+++ b/Yijing.maui/Views/DiagramView.xaml
@@ -1,23 +1,18 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentView
-        xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-        xmlns:views="clr-namespace:Yijing.Views"
-        x:Class="Yijing.Views.DiagramView"
-        x:Name="diaView"
-        Loaded="Page_Loaded"
-        >
-
-	<!--BackgroundColor="{Binding CardColor}"
-		BorderColor="{Binding BorderColor}"-->
+		xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		xmlns:views="clr-namespace:Yijing.Views"
+		x:Class="Yijing.Views.DiagramView"
+		x:Name="diaView"
+		Loaded="Page_Loaded">
 
 	<ScrollView>
 
-                <Border
-                        BindingContext="{x:Reference diaView}"
-                        x:DataType="views:DiagramView"
-                        BackgroundColor="{Binding CardColor}"
-			>
+		<Border
+			BindingContext="{x:Reference diaView}"
+			x:DataType="views:DiagramView"
+			BackgroundColor="{Binding CardColor}">
 
 			<StackLayout
 				Orientation="Vertical"

--- a/Yijing.maui/Views/EegView.xaml
+++ b/Yijing.maui/Views/EegView.xaml
@@ -1,19 +1,21 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentView 
-	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-	x:Class="Yijing.Views.EegView"
-	x:Name="eegView"
-	Loaded="Page_Loaded">
+<ContentView
+        xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        xmlns:views="clr-namespace:Yijing.Views"
+        x:Class="Yijing.Views.EegView"
+        x:Name="eegView"
+        Loaded="Page_Loaded">
 
 	<!--BackgroundColor="{Binding CardColor}"
 		BorderColor="{Binding BorderColor}"-->
 
 	<ScrollView>
 		
-		<Border 
-			BindingContext="{x:Reference eegView}"
-			BackgroundColor="{Binding CardColor}"
+                <Border
+                        BindingContext="{x:Reference eegView}"
+                        x:DataType="views:EegView"
+                        BackgroundColor="{Binding CardColor}"
 			>
 
 			<StackLayout

--- a/Yijing.maui/Views/EegView.xaml
+++ b/Yijing.maui/Views/EegView.xaml
@@ -1,22 +1,18 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentView
-        xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-        xmlns:views="clr-namespace:Yijing.Views"
-        x:Class="Yijing.Views.EegView"
-        x:Name="eegView"
-        Loaded="Page_Loaded">
-
-	<!--BackgroundColor="{Binding CardColor}"
-		BorderColor="{Binding BorderColor}"-->
+		xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		xmlns:views="clr-namespace:Yijing.Views"
+		x:Class="Yijing.Views.EegView"
+		x:Name="eegView"
+		Loaded="Page_Loaded">
 
 	<ScrollView>
 		
-                <Border
-                        BindingContext="{x:Reference eegView}"
-                        x:DataType="views:EegView"
-                        BackgroundColor="{Binding CardColor}"
-			>
+		<Border
+			BindingContext="{x:Reference eegView}"
+			x:DataType="views:EegView"
+			BackgroundColor="{Binding CardColor}">
 
 			<StackLayout
 				Orientation="Vertical"


### PR DESCRIPTION
## Summary
- register the Yijing.Views namespace in DiagramView and EegView XAML files
- enable compiled bindings for the CardColor property on each view's Border container

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8baae96fc832b9ba99bef2104cd71