### PR TITLE
Add session management page with AI integration

### DIFF
--- a/Yijing.maui/AppShell.xaml
+++ b/Yijing.maui/AppShell.xaml
@@ -7,15 +7,22 @@
 	Shell.FlyoutBehavior="Flyout"
 	Loaded="Page_Loaded">
 
-	<ShellContent
-		x:Name="pagDiagram"
+        <ShellContent
+                x:Name="pagDiagram"
         Shell.NavBarIsVisible="false"
         Title="Diagram"
         Icon="iconlistdetail.png"
         ContentTemplate="{DataTemplate pages:DiagramPage}"
         Route="Pages.DiagramPage" />
-	<ShellContent
-		x:Name="pagEeg"
+        <ShellContent
+                x:Name="pagSession"
+        Shell.NavBarIsVisible="false"
+        Title="Session"
+        Icon="iconlistdetail.png"
+        ContentTemplate="{DataTemplate pages:SessionPage}"
+        Route="Pages.SessionPage" />
+        <ShellContent
+                x:Name="pagEeg"
         Shell.NavBarIsVisible="false"
         Title="Eeg"
         Icon="iconlistdetail.png"

--- a/Yijing.maui/Pages/SessionPage.xaml
+++ b/Yijing.maui/Pages/SessionPage.xaml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+        xmlns:views="clr-namespace:Yijing.Views"
+        x:Class="Yijing.Pages.SessionPage"
+        Title="Session"
+        Loaded="Page_Loaded">
+
+        <toolkit:DockLayout
+                Padding="10,10,10,10"
+                VerticalSpacing="10"
+                HorizontalSpacing="10"
+                ShouldExpandLastChild="true">
+
+                <views:SessionView
+                        x:Name="sessionView"
+                        toolkit:DockLayout.DockPosition="Left"
+                        WidthRequest="400"
+                        ChatUpdated="SessionView_ChatUpdated" />
+
+                <VerticalStackLayout
+                        toolkit:DockLayout.DockPosition="Bottom"
+                        HeightRequest="200"
+                        Spacing="10">
+
+                        <HorizontalStackLayout
+                                Spacing="10">
+                                <Label
+                                        Text="Chat Service"
+                                        VerticalTextAlignment="Center" />
+                                <Picker
+                                        x:Name="picAiChatService"
+                                        SelectedIndexChanged="picAiChatService_SelectedIndexChanged">
+                                        <Picker.Items>
+                                                <x:String>OpenAi</x:String>
+                                                <x:String>Deepseek</x:String>
+                                                <x:String>Github</x:String>
+                                                <x:String>Ollama</x:String>
+                                                <x:String>None</x:String>
+                                        </Picker.Items>
+                                </Picker>
+                                <Button
+                                        x:Name="btnAskAi"
+                                        Text="Ask AI"
+                                        Clicked="btnAskAi_Clicked" />
+                        </HorizontalStackLayout>
+
+                        <Editor
+                                x:Name="edtSessionLog"
+                                HeightRequest="150" />
+                </VerticalStackLayout>
+
+                <WebView
+                        x:Name="webview" />
+        </toolkit:DockLayout>
+</ContentPage>

--- a/Yijing.maui/Pages/SessionPage.xaml.cs
+++ b/Yijing.maui/Pages/SessionPage.xaml.cs
@@ -1,0 +1,40 @@
+using Yijing.Services;
+using Yijing.Views;
+
+namespace Yijing.Pages;
+
+public partial class SessionPage : ContentPage
+{
+        public Editor SessionLog() => edtSessionLog;
+        public WebView WebView() => webview;
+
+        public SessionPage()
+        {
+                Behaviors.Add(new RegisterInViewDirectoryBehavior());
+                InitializeComponent();
+
+                picAiChatService.SelectedIndex = AppPreferences.AiChatService;
+                btnAskAi.IsEnabled = AppPreferences.AiChatService != (int)eAiService.eNone;
+        }
+
+        private void Page_Loaded(object sender, EventArgs e)
+        {
+        }
+
+        private void SessionView_ChatUpdated(object sender, string html)
+        {
+                webview.Source = new HtmlWebViewSource { Html = html };
+        }
+
+        private async void btnAskAi_Clicked(object sender, EventArgs e)
+        {
+                await sessionView.AiChatAsync(edtSessionLog.Text ?? string.Empty);
+                edtSessionLog.Text = string.Empty;
+        }
+
+        private void picAiChatService_SelectedIndexChanged(object sender, EventArgs e)
+        {
+                AppPreferences.AiChatService = picAiChatService.SelectedIndex;
+                btnAskAi.IsEnabled = AppPreferences.AiChatService != (int)eAiService.eNone;
+        }
+}

--- a/Yijing.maui/Views/SessionView.xaml
+++ b/Yijing.maui/Views/SessionView.xaml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView
+        xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        xmlns:views="clr-namespace:Yijing.Views"
+        x:Class="Yijing.Views.SessionView"
+        x:Name="sessionView"
+        Loaded="OnLoaded">
+
+        <Grid
+                RowDefinitions="Auto,Auto,*"
+                RowSpacing="8">
+                <HorizontalStackLayout
+                        Grid.Row="0"
+                        Spacing="12">
+                        <Button
+                                Text="Add"
+                                Clicked="OnAddSessionClicked"
+                                StyleClass="PrimaryAction" />
+                        <Button
+                                Text="Delete"
+                                Clicked="OnDeleteSessionClicked" />
+                </HorizontalStackLayout>
+
+                <Grid
+                        Grid.Row="1"
+                        ColumnDefinitions="*,2*"
+                        ColumnSpacing="12">
+                        <Label
+                                Text="Session"
+                                FontAttributes="Bold"
+                                VerticalTextAlignment="Center" />
+                        <Label
+                                Grid.Column="1"
+                                Text="Description"
+                                FontAttributes="Bold"
+                                VerticalTextAlignment="Center" />
+                </Grid>
+
+                <CollectionView
+                        x:Name="sessionCollection"
+                        Grid.Row="2"
+                        ItemsSource="{Binding Sessions}"
+                        SelectionMode="Single"
+                        SelectionChanged="OnSessionsSelectionChanged">
+                        <CollectionView.ItemsLayout>
+                                <LinearItemsLayout Orientation="Vertical" />
+                        </CollectionView.ItemsLayout>
+                        <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="views:SessionSummary">
+                                        <Grid
+                                                Padding="4,8"
+                                                ColumnDefinitions="*,2*"
+                                                ColumnSpacing="12">
+                                                <Label
+                                                        Text="{Binding Session}"
+                                                        VerticalTextAlignment="Center"
+                                                        LineBreakMode="TailTruncation" />
+                                                <Label
+                                                        Grid.Column="1"
+                                                        Text="{Binding Description}"
+                                                        VerticalTextAlignment="Center"
+                                                        LineBreakMode="TailTruncation" />
+                                        </Grid>
+                                </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                </CollectionView>
+        </Grid>
+</ContentView>

--- a/Yijing.maui/Views/SessionView.xaml.cs
+++ b/Yijing.maui/Views/SessionView.xaml.cs
@@ -1,0 +1,297 @@
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+using Microsoft.Maui.Controls;
+
+using Yijing.Services;
+
+namespace Yijing.Views;
+
+public partial class SessionView : ContentView
+{
+        private readonly ObservableCollection<SessionSummary> _sessions = new();
+        private SessionSummary? _selectedSession;
+        private readonly Ai _ai = new();
+
+        public ObservableCollection<SessionSummary> Sessions => _sessions;
+
+        public event EventHandler<string>? ChatUpdated;
+
+        public SessionView()
+        {
+                Behaviors.Add(new RegisterInViewDirectoryBehavior());
+                InitializeComponent();
+                BindingContext = this;
+
+                _ai._systemPrompts[0] =
+                        "This app allows a user to consult the Yijing and engage in casual conversation with AI. " +
+                        "Don't explain what the Yijing is or how it works unless explicitly asked. " +
+                        "Not all consultations with the Yijing, and therefore AI, involve a question that needs an answer, like those " +
+                        "which are simply a reflective statement that seeks to explore for enjoyment rather than map for remedy. " +
+                        "The question/statement and the Yijing's response will then be sent to the AI for comment. " +
+                        "Respond in light of the Yijing's answer unless told to ignore it. " +
+                        "Focus on an explanation of question/statement and draw from any other relevant sources. " +
+                        "After the initial response don't repeat or rehash the answer refering to the hexagram again unless explicitly asked to do so. " +
+                        "Subsequent 'on topic' questions/statements won't necessarily be related to the cast hexagram, therefore don't include that information in the response. " +
+                        "At least reference the ideas associated with hexagrams cast if mentioned in the current prompt " +
+                        "Don't repeat or summarise previous answers unless explicitly ask to do so. " +
+                        "Allow the user to change the subject or ask for clarification about past responses. " +
+                        "Respond with prose rather than bullet points unless explicitly asked. " +
+                        "You may call functions when needed.";
+        }
+
+        private void OnLoaded(object? sender, EventArgs e)
+        {
+                Loaded -= OnLoaded;
+                LoadSessions(null);
+                ResetChat();
+        }
+
+        public async Task AiChatAsync(string prompt)
+        {
+                if (string.IsNullOrWhiteSpace(prompt))
+                        return;
+
+                if (AppPreferences.AiChatService == (int)eAiService.eNone)
+                        return;
+
+                await _ai.ChatAsync(AppPreferences.AiChatService, prompt);
+                UpdateChat();
+        }
+
+        private void ResetChat()
+        {
+                _ai._userPrompts = [[], []];
+                _ai._chatReponses = [[], []];
+                _ai._contextSessions = [];
+                UpdateChat();
+        }
+
+        private void UpdateChat()
+        {
+                string background = App.Current?.RequestedTheme == AppTheme.Dark ? "#000000" : "#FFFFFF";
+                string foreground = App.Current?.RequestedTheme == AppTheme.Dark ? "#FFFFFF" : "#000000";
+
+                var sb = new StringBuilder();
+                sb.Append("<html><head><meta charset=\"utf-8\"/><style>");
+                sb.Append("body{");
+                sb.Append($"background-color:{background};color:{foreground};font-family:'Open Sans',sans-serif;font-size:16px;line-height:1.5;}");
+                sb.Append("strong{color:" + foreground + ";}");
+                sb.Append("</style></head><body>");
+
+                int count = Math.Max(_ai._userPrompts[1].Count, _ai._chatReponses[1].Count);
+                for (int i = 0; i < count; ++i)
+                {
+                        if (i < _ai._userPrompts[1].Count)
+                        {
+                                string encodedPrompt = WebUtility.HtmlEncode(_ai._userPrompts[1][i]).Replace("\n", "<br/>");
+                                sb.Append($"<p><strong>User:</strong> {encodedPrompt}</p>");
+                        }
+                        if (i < _ai._chatReponses[1].Count)
+                        {
+                                string encodedResponse = WebUtility.HtmlEncode(_ai._chatReponses[1][i]).Replace("\n", "<br/>");
+                                sb.Append($"<p><strong>AI:</strong> {encodedResponse}</p>");
+                        }
+                }
+
+                sb.Append("</body></html>");
+                ChatUpdated?.Invoke(this, sb.ToString());
+        }
+
+        private void LoadSessions(string? selectFile)
+        {
+                _sessions.Clear();
+
+                try
+                {
+                        string folder = GetQuestionsFolder();
+                        if (string.IsNullOrEmpty(folder))
+                                return;
+
+                        if (!Directory.Exists(folder))
+                                Directory.CreateDirectory(folder);
+
+                        IEnumerable<string> files = Directory.EnumerateFiles(folder, "*.txt", SearchOption.TopDirectoryOnly)
+                                .OrderByDescending(f => f, StringComparer.OrdinalIgnoreCase);
+
+                        foreach (string file in files)
+                        {
+                                var summary = CreateSummary(file);
+                                _sessions.Add(summary);
+                        }
+
+                        if (!string.IsNullOrEmpty(selectFile))
+                        {
+                                var match = _sessions.FirstOrDefault(s => s.FileName.Equals(selectFile, StringComparison.OrdinalIgnoreCase));
+                                if (match is not null)
+                                {
+                                        sessionCollection.SelectedItem = match;
+                                        sessionCollection.ScrollTo(match, position: ScrollToPosition.Center, animate: false);
+                                }
+                        }
+                        else if (_sessions.Count > 0)
+                        {
+                                sessionCollection.SelectedItem = _sessions[0];
+                        }
+                }
+                catch (Exception ex)
+                {
+                        System.Diagnostics.Debug.WriteLine($"Failed to load sessions: {ex.Message}");
+                }
+        }
+
+        private SessionSummary CreateSummary(string filePath)
+        {
+                string fileName = Path.GetFileNameWithoutExtension(filePath);
+                string display = FormatSessionName(fileName);
+                string description = GetSessionDescription(filePath);
+                return new SessionSummary(fileName, display, description);
+        }
+
+        private static string FormatSessionName(string fileName)
+        {
+                if (DateTime.TryParseExact(fileName, "yyyy-MM-dd-HH-mm-ss", CultureInfo.InvariantCulture,
+                        DateTimeStyles.AssumeLocal, out DateTime dt))
+                {
+                        return dt.ToString("yyyy MMM dd HH:mm:ss", CultureInfo.InvariantCulture);
+                }
+
+                return fileName;
+        }
+
+        private static string GetSessionDescription(string filePath)
+        {
+                try
+                {
+                        if (!File.Exists(filePath))
+                                return string.Empty;
+
+                        string text = File.ReadAllText(filePath);
+                        if (string.IsNullOrWhiteSpace(text))
+                                return string.Empty;
+
+                        string? castLine = text.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+                                .Select(line => line.Trim())
+                                .FirstOrDefault(line => line.Contains("hexagram", StringComparison.OrdinalIgnoreCase));
+
+                        if (!string.IsNullOrEmpty(castLine))
+                                return castLine;
+
+                        return GetFirstWords(text, 10);
+                }
+                catch (Exception ex)
+                {
+                        System.Diagnostics.Debug.WriteLine($"Failed to read session '{filePath}': {ex.Message}");
+                        return string.Empty;
+                }
+        }
+
+        private static string GetFirstWords(string text, int count)
+        {
+                if (string.IsNullOrWhiteSpace(text))
+                        return string.Empty;
+
+                var words = text.Split(new[] { ' ', '\r', '\n', '\t' }, StringSplitOptions.RemoveEmptyEntries).Take(count);
+                return string.Join(" ", words);
+        }
+
+        private static string GetQuestionsFolder()
+        {
+                string? documentHome = AppSettings.DocumentHome();
+                if (string.IsNullOrWhiteSpace(documentHome))
+                {
+                        string documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+                        documentHome = Path.Combine(documents, "Yijing");
+                }
+
+                return Path.Combine(documentHome, "Questions");
+        }
+
+        private async void OnAddSessionClicked(object? sender, EventArgs e)
+        {
+                try
+                {
+                        string folder = GetQuestionsFolder();
+                        if (!Directory.Exists(folder))
+                                Directory.CreateDirectory(folder);
+
+                        string fileName = AppSettings.ReverseDateString();
+                        string path = Path.Combine(folder, fileName + ".txt");
+                        if (!File.Exists(path))
+                                File.WriteAllText(path, string.Empty);
+
+                        LoadSessions(fileName);
+                }
+                catch (Exception ex)
+                {
+                        await ShowAlert("Add Session", $"Unable to create a session. {ex.Message}");
+                }
+        }
+
+        private async void OnDeleteSessionClicked(object? sender, EventArgs e)
+        {
+                if (_selectedSession is null)
+                        return;
+
+                bool confirm = await ConfirmAsync("Delete Session",
+                        $"Delete {_selectedSession.Session}?");
+                if (!confirm)
+                        return;
+
+                try
+                {
+                        string folder = GetQuestionsFolder();
+                        string path = Path.Combine(folder, _selectedSession.FileName + ".txt");
+                        if (File.Exists(path))
+                                File.Delete(path);
+
+                        LoadSessions(null);
+                }
+                catch (Exception ex)
+                {
+                        await ShowAlert("Delete Session", $"Unable to delete the session. {ex.Message}");
+                }
+        }
+
+        private void OnSessionsSelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+                _selectedSession = e.CurrentSelection.FirstOrDefault() as SessionSummary;
+        }
+
+        private static Task ShowAlert(string title, string message)
+        {
+                if (Application.Current?.MainPage is Page page)
+                        return page.DisplayAlert(title, message, "OK");
+
+                return Task.CompletedTask;
+        }
+
+        private static Task<bool> ConfirmAsync(string title, string message)
+        {
+                if (Application.Current?.MainPage is Page page)
+                        return page.DisplayAlert(title, message, "Yes", "No");
+
+                return Task.FromResult(false);
+        }
+}
+
+public class SessionSummary
+{
+        public SessionSummary(string fileName, string session, string description)
+        {
+                FileName = fileName;
+                Session = session;
+                Description = description;
+        }
+
+        public string FileName { get; }
+
+        public string Session { get; }
+
+        public string Description { get; }
+}


### PR DESCRIPTION
## Summary
- add a new Session page to the shell navigation alongside the existing Diagram view
- implement a SessionView grid with add/delete controls that reads session files from Documents/Yijing/Questions
- reuse the AI chat controls to drive SessionView conversations and render responses in the page webview

## Testing
- `dotnet build Yijing.maui/Yijing.maui.csproj` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8c93f95c0832b85f3327b714da3e8