### PR TITLE
Refine session list layout

### DIFF
--- a/Yijing.maui/Views/SessionView.xaml
+++ b/Yijing.maui/Views/SessionView.xaml
@@ -50,7 +50,7 @@
 
 				<CollectionView.ItemTemplate>
 					<DataTemplate x:DataType="models:Session">
-						<Border BackgroundColor="{AppThemeBinding Light=LightGray, Dark=#404040}" Padding="10,8">
+						<Border BackgroundColor="{AppThemeBinding Light=White, Dark=Black}" Padding="5,5">
 							<VerticalStackLayout Spacing="4">
 								<Grid ColumnDefinitions="*,Auto">
 									<Label

--- a/Yijing.maui/Views/SessionView.xaml
+++ b/Yijing.maui/Views/SessionView.xaml
@@ -4,11 +4,11 @@
 	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
-	
+
 	xmlns:models="clr-namespace:YijingData;assembly=Yijing.data"
 	xmlns:views="clr-namespace:Yijing.Views"
 	xmlns:controls="clr-namespace:Yijing.Controls"
-	xmlns:conv="clr-namespace:Yijing.Services"	
+	xmlns:conv="clr-namespace:Yijing.Services"
 
 	x:Class="Yijing.Views.SessionView"
 	x:Name="sessionView"
@@ -24,122 +24,62 @@
 	</ContentView.Resources>
 
 	<Border>
-	<Grid
-		RowDefinitions="Auto,Auto,*"
-		>
+		<Grid RowDefinitions="Auto,*">
+			<HorizontalStackLayout
+				x:Name="hslButtons"
+				Grid.Row="0">
+				<controls:ButtonEx
+					x:Name="btnAdd"
+					Icon="{x:Static controls:FluentIcons.Add}"
+					Clicked="OnAddSessionClicked" />
+				<controls:ButtonEx
+					x:Name="btnDelete"
+					Icon="{x:Static controls:FluentIcons.Delete}"
+					Clicked="OnDeleteSessionClicked" />
+			</HorizontalStackLayout>
 
-		<HorizontalStackLayout
-			x:Name="hslButtons"
-			Grid.Row="0"
-			>
+			<CollectionView
+				x:Name="sessionCollection"
+				Grid.Row="1"
+				ItemsSource="{Binding Sessions}"
+				SelectionMode="Single"
+				SelectionChanged="OnSessionsSelectionChanged">
+				<CollectionView.ItemsLayout>
+					<LinearItemsLayout Orientation="Vertical" />
+				</CollectionView.ItemsLayout>
 
-			<controls:ButtonEx
-				x:Name="btnAdd"
-				Icon="{x:Static controls:FluentIcons.Add}"
-				Clicked="OnAddSessionClicked"
-				/>
-			<controls:ButtonEx
-				x:Name="btnDelete"
-				Icon="{x:Static controls:FluentIcons.Delete}"
-				Clicked="OnDeleteSessionClicked"
-				/>
-			
-		</HorizontalStackLayout>
-
-		<Grid
-			x:Name="grdLabels"
-			Grid.Row="1"
-			Padding="10,4"
-			ColumnDefinitions="90,12,12,12,12,*"
-			ColumnSpacing="12"
-			>
-			
-			<Label
-				Text="Session"
-				FontAttributes="Bold"
-				VerticalTextAlignment="Center" />
-
-			<Label
-				Grid.Column="1"
-				Text="Y"
-				FontAttributes="Bold"
-				VerticalTextAlignment="Center" />
-
-			<Label
-				Grid.Column="2"
-				Text="M"
-				FontAttributes="Bold"
-				VerticalTextAlignment="Center" />
-
-			<Label
-				Grid.Column="3"
-				Text="E"
-				FontAttributes="Bold"
-				VerticalTextAlignment="Center" />
-
-			<Label
-				Grid.Column="4"
-				Text="A"
-				FontAttributes="Bold"
-				VerticalTextAlignment="Center" />
-
-			<Label
-				Grid.Column="5"
-				Text="Description"
-				LineBreakMode="TailTruncation"
-				FontAttributes="Bold"
-				VerticalTextAlignment="Center" />
-
+				<CollectionView.ItemTemplate>
+					<DataTemplate x:DataType="models:Session">
+						<Border BackgroundColor="{AppThemeBinding Light=LightGray, Dark=#404040}" Padding="10,8">
+							<VerticalStackLayout Spacing="4">
+								<Grid ColumnDefinitions="*,Auto">
+									<Label
+										Text="{Binding Name}"
+										VerticalTextAlignment="Center"
+										LineBreakMode="TailTruncation" />
+									<HorizontalStackLayout Grid.Column="1" HorizontalOptions="End" Spacing="8">
+										<Label
+											Text="{Binding YijingCast, Converter={StaticResource YijingCastConverter}}"
+											VerticalTextAlignment="Center" />
+										<Label
+											Text="{Binding Meditation, Converter={StaticResource MeditationConverter}}"
+											VerticalTextAlignment="Center" />
+										<Label
+											Text="{Binding EegDevice, Converter={StaticResource EegDeviceConverter}}"
+											VerticalTextAlignment="Center" />
+										<Label
+											Text="{Binding EegAnalysis, Converter={StaticResource AnalysisConverter}}"
+											VerticalTextAlignment="Center" />
+									</HorizontalStackLayout>
+								</Grid>
+								<Label
+									Text="{Binding Description}"
+									LineBreakMode="WordWrap" />
+							</VerticalStackLayout>
+						</Border>
+					</DataTemplate>
+				</CollectionView.ItemTemplate>
+			</CollectionView>
 		</Grid>
-
-		<CollectionView
-			x:Name="sessionCollection"
-			Grid.Row="2"
-			ItemsSource="{Binding Sessions}"
-			SelectionMode="Single"
-			SelectionChanged="OnSessionsSelectionChanged">
-
-			<CollectionView.ItemsLayout>
-				<LinearItemsLayout Orientation="Vertical" />
-			</CollectionView.ItemsLayout>
-
-			<CollectionView.ItemTemplate>
-
-				<DataTemplate x:DataType="models:Session">
-					<Grid
-						Padding="10,4"
-						ColumnDefinitions="90,12,12,12,12,*"
-						ColumnSpacing="12">
-
-						<Label
-							Text="{Binding Name}"
-							VerticalTextAlignment="Center"
-							LineBreakMode="TailTruncation" />
-						<Label
-							Grid.Column="1"
-							Text="{Binding YijingCast, Converter={StaticResource YijingCastConverter}}"
-							VerticalTextAlignment="Center"/>
-						<Label
-							Grid.Column="2"
-							Text="{Binding Meditation, Converter={StaticResource MeditationConverter}}"
-							VerticalTextAlignment="Center"/>
-						<Label
-							Grid.Column="3"
-							Text="{Binding EegDevice, Converter={StaticResource EegDeviceConverter}}"
-							VerticalTextAlignment="Center"/>
-						<Label
-							Grid.Column="4"
-							Text="{Binding EegAnalysis, Converter={StaticResource AnalysisConverter}}"
-							VerticalTextAlignment="Center"/>
-						<Label
-							Grid.Column="5"
-							Text="{Binding Description}"
-							VerticalTextAlignment="Center"
-							LineBreakMode="TailTruncation" />
-					</Grid>
-				</DataTemplate>
-			</CollectionView.ItemTemplate>
-		</CollectionView>
-	</Grid>
 	</Border>
 </ContentView>

--- a/Yijing.maui/Views/SessionView.xaml.cs
+++ b/Yijing.maui/Views/SessionView.xaml.cs
@@ -35,7 +35,6 @@ public partial class SessionView : ContentView
 		if (App.Current!.RequestedTheme == AppTheme.Dark)
 		{
 			hslButtons.BackgroundColor = Colors.Black;
-			grdLabels.BackgroundColor = Colors.Black;
 			sessionCollection.BackgroundColor = Colors.Black;
 		}
 


### PR DESCRIPTION
## Summary
- remove the multi-column header and redesign session entries into a stacked layout
- right-align the Y/E/M/A indicators within each row
- add theme-aware background styling and multi-line descriptions for sessions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695369850f54832b9660f8ed5128cb20)