### PR TITLE
Use exponential trigger adjustment in MindCast

### DIFF
--- a/Yijing.maui/Views/DiagramView.xaml.cs
+++ b/Yijing.maui/Views/DiagramView.xaml.cs
@@ -1273,65 +1273,69 @@ public partial class DiagramView : ContentView
 				//App.EegChannel(23).m_fMinValue = 1000.0f;
 				//App.EegChannel(23).m_fMaxValue = -1000.0f;
 
-				DateTime start = DateTime.Now;
-				TimeSpan ts = DateTime.Now - start;
+				DateTime lastUpdate = DateTime.Now;
 				const float triggerChangeTarget = 0.1f;
+				float rampProgress = 0.0f;
 				float lastChange = 0.0f;
-
+				
 				int count = 0;
 				//App.EegSetTriggers(true, true);
 				while (ev.EegIsConnected() && !ev.EegIsTriggerOn())
 				{
-					await Task.Delay(200);
-					if (AppPreferences.TriggerSounding && (ev.EegReplaySpeed() == 1) && (++count % 50 == 0))
-						SoundTrigger(ev.EegChannel(AppPreferences.TriggerIndex).m_fCurrentValue * AppPreferences.AudioScale,
-							ev.EegChannel(AppPreferences.TriggerIndex).m_fHigh * AppPreferences.AudioScale);
-					ts = DateTime.Now - start;
-					int speed = m_nTriggerSpeed * ev.EegReplaySpeed();
-					speed = speed > 50 ? 50 : speed;
-					if (!AppPreferences.TriggerFixed)
-					{
-						float progress = (float)(ts.TotalSeconds * speed / 60.0f);
-						float change = triggerChangeTarget * (float)Math.Min(1.0f, (float)Math.Exp(progress) / (float)Math.Exp(1.0f));
-						float delta = change - lastChange;
-						if (delta > 0.0f)
-							ev.EegDecreaseTriggers(delta);
-						lastChange = change;
-					}
+				await Task.Delay(200);
+				if (AppPreferences.TriggerSounding && (ev.EegReplaySpeed() == 1) && (++count % 50 == 0))
+				SoundTrigger(ev.EegChannel(AppPreferences.TriggerIndex).m_fCurrentValue * AppPreferences.AudioScale,
+				ev.EegChannel(AppPreferences.TriggerIndex).m_fHigh * AppPreferences.AudioScale);
+				DateTime now = DateTime.Now;
+				rampProgress += (float)(now - lastUpdate).TotalSeconds;
+				lastUpdate = now;
+				int speed = m_nTriggerSpeed * ev.EegReplaySpeed();
+				speed = speed > 50 ? 50 : speed;
+				if (!AppPreferences.TriggerFixed)
+				{
+				float progress = (float)(rampProgress * speed / 60.0f);
+				float change = triggerChangeTarget * ((float)Math.Exp(progress) - 1.0f);
+				float delta = change - lastChange;
+				if (delta > 0.0f)
+				ev.EegDecreaseTriggers(delta);
+				lastChange = change;
+				}
 				}
 				if (!ev.EegIsConnected())
 					break;
 				if (AppPreferences.TriggerSounding)
 					SoundTrigger(ev.EegChannel(AppPreferences.TriggerIndex).m_fCurrentValue * AppPreferences.AudioScale, 0.0f);
-
+				
 				m_timDiagram.Change(0, m_nSpeeds[(int)eDiagramSpeed.eFast]);
-
-				start = DateTime.Now;
-				ts = DateTime.Now - start;
+				
+				lastUpdate = DateTime.Now;
+				rampProgress = 0.0f;
 				lastChange = 0.0f;
-
+				
 				count = 0;
 				//App.EegSetTriggers(true, false);
 				while (ev.EegIsConnected() && !ev.EegIsTriggerOff())
 				{
-					await Task.Delay(200);
-					if (AppPreferences.TriggerSounding && (ev.EegReplaySpeed() == 1) && (++count % 50 == 0))
-						SoundTrigger(ev.EegChannel(AppPreferences.TriggerIndex).m_fCurrentValue * AppPreferences.AudioScale,
-							ev.EegChannel(AppPreferences.TriggerIndex).m_fLow * AppPreferences.AudioScale);
-					ts = DateTime.Now - start;
-					int speed = m_nTriggerSpeed * ev.EegReplaySpeed();
-					speed = speed > 50 ? 50 : speed;
-					if (!AppPreferences.TriggerFixed)
-					{
-						float progress = (float)(ts.TotalSeconds * speed / 60.0f);
-						float change = triggerChangeTarget * (float)Math.Min(1.0f, (float)Math.Exp(progress) / (float)Math.Exp(1.0f));
-						float delta = change - lastChange;
-						if (delta > 0.0f)
-							ev.EegIncreaseTriggers(delta);
-						lastChange = change;
-					}
+				await Task.Delay(200);
+				if (AppPreferences.TriggerSounding && (ev.EegReplaySpeed() == 1) && (++count % 50 == 0))
+				SoundTrigger(ev.EegChannel(AppPreferences.TriggerIndex).m_fCurrentValue * AppPreferences.AudioScale,
+				ev.EegChannel(AppPreferences.TriggerIndex).m_fLow * AppPreferences.AudioScale);
+				DateTime now = DateTime.Now;
+				rampProgress += (float)(now - lastUpdate).TotalSeconds;
+				lastUpdate = now;
+				int speed = m_nTriggerSpeed * ev.EegReplaySpeed();
+				speed = speed > 50 ? 50 : speed;
+				if (!AppPreferences.TriggerFixed)
+				{
+				float progress = (float)(rampProgress * speed / 60.0f);
+				float change = triggerChangeTarget * ((float)Math.Exp(progress) - 1.0f);
+				float delta = change - lastChange;
+				if (delta > 0.0f)
+				ev.EegIncreaseTriggers(delta);
+				lastChange = change;
 				}
-
+				}
+				
 				//App.EegCalculateTriggers();
 				m_timDiagram.Change(Timeout.Infinite, 0);
 				if (!ev.EegIsConnected())

--- a/Yijing.maui/Views/DiagramView.xaml.cs
+++ b/Yijing.maui/Views/DiagramView.xaml.cs
@@ -1275,7 +1275,7 @@ public partial class DiagramView : ContentView
 
 				DateTime start = DateTime.Now;
 				TimeSpan ts = DateTime.Now - start;
-				const float triggerChangeTarget = 1.08f;
+				const float triggerChangeTarget = 0.1f;
 				float lastChange = 0.0f;
 
 				int count = 0;
@@ -1292,7 +1292,7 @@ public partial class DiagramView : ContentView
 					if (!AppPreferences.TriggerFixed)
 					{
 						float progress = (float)(ts.TotalSeconds * speed / 60.0f);
-						float change = (1.0f - (float)Math.Exp(-progress)) * triggerChangeTarget;
+						float change = triggerChangeTarget * (float)Math.Min(1.0f, (float)Math.Exp(progress) / (float)Math.Exp(1.0f));
 						float delta = change - lastChange;
 						if (delta > 0.0f)
 							ev.EegDecreaseTriggers(delta);
@@ -1324,7 +1324,7 @@ public partial class DiagramView : ContentView
 					if (!AppPreferences.TriggerFixed)
 					{
 						float progress = (float)(ts.TotalSeconds * speed / 60.0f);
-						float change = (1.0f - (float)Math.Exp(-progress)) * triggerChangeTarget;
+						float change = triggerChangeTarget * (float)Math.Min(1.0f, (float)Math.Exp(progress) / (float)Math.Exp(1.0f));
 						float delta = change - lastChange;
 						if (delta > 0.0f)
 							ev.EegIncreaseTriggers(delta);

--- a/Yijing.maui/Views/DiagramView.xaml.cs
+++ b/Yijing.maui/Views/DiagramView.xaml.cs
@@ -1257,35 +1257,35 @@ public partial class DiagramView : ContentView
 	}
 #endif
 
-		private async Task MindCast()
+	private async Task MindCast()
+	{
+		//Random r = true ? Sequences.m_ranSession : new Random(DateTime.Now.Millisecond);
+		EegView ev = UI.Get<EegView>();
+		ev.EegSetTriggers(true, true);
+		for (int i = 0; i < 6; ++i)
 		{
-			//Random r = true ? Sequences.m_ranSession : new Random(DateTime.Now.Millisecond);
-			EegView ev = UI.Get<EegView>();
-			ev.EegSetTriggers(true, true);
-			for (int i = 0; i < 6; ++i)
+			SetCurrentLine(i, true);
+			UpdateDiagram(false);
+
+			//App.EegChannel(AppPreferences.TriggerIndex).m_fMinValue = 1000.0f;
+			//App.EegChannel(AppPreferences.TriggerIndex).m_fMaxValue = -1000.0f;
+
+			//App.EegChannel(23).m_fMinValue = 1000.0f;
+			//App.EegChannel(23).m_fMaxValue = -1000.0f;
+
+			DateTime lastUpdate = DateTime.Now;
+			const float triggerChangeTarget = 0.0001f;
+			float rampProgress = 0.0f;
+			float lastChange = 0.0f;
+
+			int count = 0;
+			//App.EegSetTriggers(true, true);
+			while (ev.EegIsConnected() && !ev.EegIsTriggerOn())
 			{
-				SetCurrentLine(i, true);
-				UpdateDiagram(false);
-
-				//App.EegChannel(AppPreferences.TriggerIndex).m_fMinValue = 1000.0f;
-				//App.EegChannel(AppPreferences.TriggerIndex).m_fMaxValue = -1000.0f;
-
-				//App.EegChannel(23).m_fMinValue = 1000.0f;
-				//App.EegChannel(23).m_fMaxValue = -1000.0f;
-
-				DateTime lastUpdate = DateTime.Now;
-				const float triggerChangeTarget = 0.1f;
-				float rampProgress = 0.0f;
-				float lastChange = 0.0f;
-				
-				int count = 0;
-				//App.EegSetTriggers(true, true);
-				while (ev.EegIsConnected() && !ev.EegIsTriggerOn())
-				{
 				await Task.Delay(200);
 				if (AppPreferences.TriggerSounding && (ev.EegReplaySpeed() == 1) && (++count % 50 == 0))
-				SoundTrigger(ev.EegChannel(AppPreferences.TriggerIndex).m_fCurrentValue * AppPreferences.AudioScale,
-				ev.EegChannel(AppPreferences.TriggerIndex).m_fHigh * AppPreferences.AudioScale);
+					SoundTrigger(ev.EegChannel(AppPreferences.TriggerIndex).m_fCurrentValue * AppPreferences.AudioScale,
+					ev.EegChannel(AppPreferences.TriggerIndex).m_fHigh * AppPreferences.AudioScale);
 				DateTime now = DateTime.Now;
 				rampProgress += (float)(now - lastUpdate).TotalSeconds;
 				lastUpdate = now;
@@ -1293,63 +1293,63 @@ public partial class DiagramView : ContentView
 				speed = speed > 50 ? 50 : speed;
 				if (!AppPreferences.TriggerFixed)
 				{
-				float progress = (float)(rampProgress * speed / 60.0f);
-				float change = triggerChangeTarget * ((float)Math.Exp(progress) - 1.0f);
-				float delta = change - lastChange;
-				if (delta > 0.0f)
-				ev.EegDecreaseTriggers(delta);
-				lastChange = change;
+					float progress = (float)(rampProgress * speed / 60.0f);
+					float change = triggerChangeTarget * ((float)Math.Exp(progress) - 1.0f);
+					float delta = change - lastChange;
+					if (delta > 0.0f)
+						ev.EegDecreaseTriggers(delta);
+					lastChange = change;
 				}
-				}
-				if (!ev.EegIsConnected())
-					break;
-				if (AppPreferences.TriggerSounding)
-					SoundTrigger(ev.EegChannel(AppPreferences.TriggerIndex).m_fCurrentValue * AppPreferences.AudioScale, 0.0f);
-				
-				m_timDiagram.Change(0, m_nSpeeds[(int)eDiagramSpeed.eFast]);
-				
-				lastUpdate = DateTime.Now;
-				rampProgress = 0.0f;
-				lastChange = 0.0f;
-				
-				count = 0;
-				//App.EegSetTriggers(true, false);
-				while (ev.EegIsConnected() && !ev.EegIsTriggerOff())
-				{
-				await Task.Delay(200);
-				if (AppPreferences.TriggerSounding && (ev.EegReplaySpeed() == 1) && (++count % 50 == 0))
-				SoundTrigger(ev.EegChannel(AppPreferences.TriggerIndex).m_fCurrentValue * AppPreferences.AudioScale,
-				ev.EegChannel(AppPreferences.TriggerIndex).m_fLow * AppPreferences.AudioScale);
-				DateTime now = DateTime.Now;
-				rampProgress += (float)(now - lastUpdate).TotalSeconds;
-				lastUpdate = now;
-				int speed = m_nTriggerSpeed * ev.EegReplaySpeed();
-				speed = speed > 50 ? 50 : speed;
-				if (!AppPreferences.TriggerFixed)
-				{
-				float progress = (float)(rampProgress * speed / 60.0f);
-				float change = triggerChangeTarget * ((float)Math.Exp(progress) - 1.0f);
-				float delta = change - lastChange;
-				if (delta > 0.0f)
-				ev.EegIncreaseTriggers(delta);
-				lastChange = change;
-				}
-				}
-				
-				//App.EegCalculateTriggers();
-				m_timDiagram.Change(Timeout.Infinite, 0);
-				if (!ev.EegIsConnected())
-					break;
-				if (AppPreferences.TriggerSounding)
-					SoundTrigger(ev.EegChannel(AppPreferences.TriggerIndex).m_fCurrentValue * AppPreferences.AudioScale, 0.0f);
 			}
-			await Task.Delay(100);
+			if (!ev.EegIsConnected())
+				break;
 			if (AppPreferences.TriggerSounding)
-				AudioPlayer.PlayHexagramEnd(Dispatcher);
-			void action() => EndCast();
-			Dispatcher.Dispatch(action);
+				SoundTrigger(ev.EegChannel(AppPreferences.TriggerIndex).m_fCurrentValue * AppPreferences.AudioScale, 0.0f);
+
+			m_timDiagram.Change(0, m_nSpeeds[(int)eDiagramSpeed.eFast]);
+
+			lastUpdate = DateTime.Now;
+			rampProgress = 0.0f;
+			lastChange = 0.0f;
+
+			count = 0;
+			//App.EegSetTriggers(true, false);
+			while (ev.EegIsConnected() && !ev.EegIsTriggerOff())
+			{
+				await Task.Delay(200);
+				if (AppPreferences.TriggerSounding && (ev.EegReplaySpeed() == 1) && (++count % 50 == 0))
+					SoundTrigger(ev.EegChannel(AppPreferences.TriggerIndex).m_fCurrentValue * AppPreferences.AudioScale,
+					ev.EegChannel(AppPreferences.TriggerIndex).m_fLow * AppPreferences.AudioScale);
+				DateTime now = DateTime.Now;
+				rampProgress += (float)(now - lastUpdate).TotalSeconds;
+				lastUpdate = now;
+				int speed = m_nTriggerSpeed * ev.EegReplaySpeed();
+				speed = speed > 50 ? 50 : speed;
+				if (!AppPreferences.TriggerFixed)
+				{
+					float progress = (float)(rampProgress * speed / 60.0f);
+					float change = triggerChangeTarget * ((float)Math.Exp(progress) - 1.0f);
+					float delta = change - lastChange;
+					if (delta > 0.0f)
+						ev.EegIncreaseTriggers(delta);
+					lastChange = change;
+				}
+			}
+
+			//App.EegCalculateTriggers();
+			m_timDiagram.Change(Timeout.Infinite, 0);
+			if (!ev.EegIsConnected())
+				break;
+			if (AppPreferences.TriggerSounding)
+				SoundTrigger(ev.EegChannel(AppPreferences.TriggerIndex).m_fCurrentValue * AppPreferences.AudioScale, 0.0f);
 		}
-		private void EndCast()
+		await Task.Delay(100);
+		if (AppPreferences.TriggerSounding)
+			AudioPlayer.PlayHexagramEnd(Dispatcher);
+		void action() => EndCast();
+		Dispatcher.Dispatch(action);
+	}
+	private void EndCast()
 	{
 		UpdateText();
 		EnableDiagramControls(true, true);


### PR DESCRIPTION
## Summary
- replace discrete trigger adjustments in MindCast with a continuous exponential ramp
- keep trigger audio cues and diagram timing while smoothing threshold changes
- ensure indentation remains consistent in DiagramView

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953a9dfdf58832b9ce54aec04fbfc2f)