### PR TITLE
Add context selection checkboxes and persist context sessions

### DIFF
--- a/Yijing.data/Session.cs
+++ b/Yijing.data/Session.cs
@@ -1,11 +1,14 @@
 namespace YijingData;
 
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 public enum eEegDevice { eMuse, eEmotiv, eNone };
 
-public partial class Session
+public partial class Session : INotifyPropertyChanged
 {
+	private bool _isContextSelected;
 
 	public Session(int id, string name, string? description = null, string? fileName = null,
 		string? yijingCast = null, bool meditation = false, eEegDevice eegDevice = eEegDevice.eNone, bool eegAnalysis = false)
@@ -36,4 +39,24 @@ public partial class Session
 	public eEegDevice EegDevice { get; set; }
 
 	public bool EegAnalysis { get; set; }
+
+	[NotMapped]
+	public bool IsContextSelected
+	{
+		get => _isContextSelected;
+		set
+		{
+			if (_isContextSelected == value)
+				return;
+			_isContextSelected = value;
+			OnPropertyChanged(nameof(IsContextSelected));
+		}
+	}
+
+	public event PropertyChangedEventHandler? PropertyChanged;
+
+	protected virtual void OnPropertyChanged(string propertyName)
+	{
+		PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+	}
 }

--- a/Yijing.maui/Views/SessionView.xaml
+++ b/Yijing.maui/Views/SessionView.xaml
@@ -52,12 +52,19 @@
 					<DataTemplate x:DataType="models:Session">
 						<Border BackgroundColor="{AppThemeBinding Light=White, Dark=Black}" Padding="5,5">
 							<VerticalStackLayout Spacing="4">
-								<Grid ColumnDefinitions="*,Auto">
+								<Grid ColumnDefinitions="Auto,*,Auto">
+									<CheckBox
+										Grid.Column="0"
+										IsChecked="{Binding IsContextSelected}"
+										CheckedChanged="OnContextSelectionChanged"
+										VerticalOptions="Center"
+										Margin="0,0,6,0" />
 									<Label
+										Grid.Column="1"
 										Text="{Binding Name}"
 										VerticalTextAlignment="Center"
 										LineBreakMode="TailTruncation" />
-									<HorizontalStackLayout Grid.Column="1" HorizontalOptions="End" Spacing="8">
+									<HorizontalStackLayout Grid.Column="2" HorizontalOptions="End" Spacing="8">
 										<Label
 											Text="{Binding YijingCast, Converter={StaticResource YijingCastConverter}}"
 											VerticalTextAlignment="Center" />

--- a/Yijing.maui/Views/SessionView.xaml.cs
+++ b/Yijing.maui/Views/SessionView.xaml.cs
@@ -696,20 +696,20 @@ public partial class SessionView : ContentView
 	{
 		for (int i = 0; i < _ai._contextSessions.Count; ++i)
 		{
-			LoadChat(_ai._contextSessions[i], "Question", _ai._userPrompts[0]);
-			LoadChat(_ai._contextSessions[i], "Answer", _ai._chatReponses[0]);
+			LoadChat(_ai._contextSessions[i], "Question", _ai._userPrompts[0], false);
+			LoadChat(_ai._contextSessions[i], "Answer", _ai._chatReponses[0], false);
 		}
 		if (!string.IsNullOrEmpty(session))
 		{
 			//EegView._strSession = session;
-			LoadChat(session, "Question", _ai._userPrompts[1]);
-			LoadChat(session, "Answer", _ai._chatReponses[1]);
+			LoadChat(session, "Question", _ai._userPrompts[1], true);
+			LoadChat(session, "Answer", _ai._chatReponses[1], true);
 			if ((_ai._userPrompts[1].Count() > 0) || (_ai._chatReponses[1].Count() > 0))
 				UpdateChat();
 		}
 	}
 
-	public void LoadChat(string name, string type, List<string> list)
+	public void LoadChat(string name, string type, List<string> list, bool allowNotes)
 	{
 		string? str = Path.Combine(AppSettings.DocumentHome(), $"{type}s", name + ".txt");
 		string entryType = "";
@@ -736,7 +736,7 @@ public partial class SessionView : ContentView
 						{
 							if (!string.IsNullOrEmpty(entryType) && (entryType == type))
 								list.Add(entry);
-							else
+							else if (allowNotes)
 								_sessionNotes.Add(entry);
 							entry = "";
 						}
@@ -749,7 +749,7 @@ public partial class SessionView : ContentView
 						{
 							if (!string.IsNullOrEmpty(entryType) && (entryType == type))
 								list.Add(entry);
-							else
+							else if (allowNotes)
 								_sessionNotes.Add(entry);
 							//list.Add(entry);
 							entry = "";
@@ -762,7 +762,7 @@ public partial class SessionView : ContentView
 						{
 							if (!string.IsNullOrEmpty(entryType) && (entryType == type))
 								list.Add(entry);
-							else
+							else if (allowNotes)
 								_sessionNotes.Add(entry);
 							//_sessionNotes.Add(entry);
 							entry = "";
@@ -776,7 +776,7 @@ public partial class SessionView : ContentView
 				if (!string.IsNullOrEmpty(entry))
 					if (!string.IsNullOrEmpty(entryType) && (entryType == type))
 						list.Add(entry);
-					else
+					else if (allowNotes)
 						_sessionNotes.Add(entry);
 			}
 		//else


### PR DESCRIPTION
### Motivation
- Allow users to mark multiple past sessions as AI context for the current session via the session list UI.  
- Persist selected context session ids in the session `Question` files so context selections survive reloads.  
- Ensure `Ai._contextSessions` and the CollectionView reflect selections when a session is loaded or when the user toggles a checkbox.

### Description
- Added a non-mapped, bindable property `IsContextSelected` to `Session` and implemented `INotifyPropertyChanged` to support UI binding (`Yijing.data/Session.cs`).  
- Inserted a `CheckBox` into the `SessionView` item template and bound it to `IsContextSelected`, and added handler `OnContextSelectionChanged` to update `Ai._contextSessions` on toggle (`Yijing.maui/Views/SessionView.xaml` and `Yijing.maui/Views/SessionView.xaml.cs`).  
- Implemented context persistence by writing a `$(Context)` section with comma-separated session ids at the top of `Questions/*.txt` when saving (`SaveChat`) and by parsing that section on load to populate `_ai._contextSessions` (`LoadContextSessions`, `SetContextSessions`, `UpdateContextSelectionFlags`) and synchronizing the checkboxes.  
- Updated `DiagramView` save/load logic to also write and ignore the `$(Context)` block so diagram-based chat saves are consistent, and adjusted `ReadText` to strip `$(Context)` lines so session metadata parsing remains correct (`Yijing.maui/Views/DiagramView.xaml.cs`, `Yijing.maui/Views/SessionView.xaml.cs`).

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c7e28dee4832ba2d9fd4b29a835ae)