### PR TITLE
Refactor chat session loading into unified section-based parser

### DIFF
--- a/Yijing.maui/Views/SessionView.xaml.cs
+++ b/Yijing.maui/Views/SessionView.xaml.cs
@@ -549,7 +549,7 @@ public partial class SessionView : ContentView
 		SaveChat(_selectedSession.FileName);
 		ClearChatState();
 		LoadChatSessionData(_selectedSession.FileName);
-		_contextSelectionDirty = false;
+		//_contextSelectionDirty = false;
 	}
 
 	private void SetContextSessions(string? value)
@@ -687,7 +687,7 @@ public partial class SessionView : ContentView
 			if (string.IsNullOrEmpty(currentSection))
 				return;
 
-			string entry = buffer.ToString().TrimEnd('\n');
+			string entry = buffer.ToString().TrimEnd(); // '\n'
 			buffer.Clear();
 
 			if (string.IsNullOrEmpty(entry))

--- a/Yijing.maui/Views/SessionView.xaml.cs
+++ b/Yijing.maui/Views/SessionView.xaml.cs
@@ -486,10 +486,7 @@ public partial class SessionView : ContentView
 	{
 		ClearChatState();
 		if (session is not null)
-		{
-			LoadContextSessions(session.FileName!);
-			LoadChat(session.FileName!);
-		}
+			LoadChatSessionData(session.FileName!);
 		UpdateChat();
 	}
 
@@ -551,41 +548,7 @@ public partial class SessionView : ContentView
 		SortContextSessions();
 		SaveChat(_selectedSession.FileName);
 		ClearChatState();
-		LoadContextSessions(_selectedSession.FileName);
-		LoadChat(_selectedSession.FileName);
-		_contextSelectionDirty = false;
-	}
-
-	private void LoadContextSessions(string session)
-	{
-		_ai._contextSessions = [];
-		string path = Path.Combine(AppSettings.DocumentHome(), "Questions", session + ".txt");
-		if (File.Exists(path))
-			using (StreamReader sr = File.OpenText(path))
-			{
-				string? line;
-				bool readContext = false;
-				while ((line = sr.ReadLine()) != null)
-				{
-					if (string.IsNullOrWhiteSpace(line))
-						continue;
-					if (line == "$(Context)")
-					{
-						readContext = true;
-						continue;
-					}
-					if (readContext)
-					{
-						if (!line.StartsWith("$("))
-							SetContextSessions(line);
-						break;
-					}
-					if (line.StartsWith("$("))
-						break;
-				}
-			}
-		SortContextSessions();
-		UpdateContextSelectionFlags();
+		LoadChatSessionData(_selectedSession.FileName);
 		_contextSelectionDirty = false;
 	}
 
@@ -685,92 +648,77 @@ public partial class SessionView : ContentView
 		}
 	}
 
-	public void LoadChat(string session)
+	public void LoadChatSessionData(string session)
 	{
+		if (string.IsNullOrEmpty(session))
+			return;
+
+		_ai._contextSessions = [];
+		LoadChatFile(session, "Question", _ai._userPrompts[1], true, true);
+		LoadChatFile(session, "Answer", _ai._chatReponses[1], false, false);
+		SortContextSessions();
+		UpdateContextSelectionFlags();
+		_contextSelectionDirty = false;
+
 		for (int i = 0; i < _ai._contextSessions.Count; ++i)
 		{
-			LoadChat(_ai._contextSessions[i], "Question", _ai._userPrompts[0], false);
-			LoadChat(_ai._contextSessions[i], "Answer", _ai._chatReponses[0], false);
+			LoadChatFile(_ai._contextSessions[i], "Question", _ai._userPrompts[0], false, false);
+			LoadChatFile(_ai._contextSessions[i], "Answer", _ai._chatReponses[0], false, false);
 		}
-		if (!string.IsNullOrEmpty(session))
-		{
-			LoadChat(session, "Question", _ai._userPrompts[1], true);
-			LoadChat(session, "Answer", _ai._chatReponses[1], true);
-			if ((_ai._userPrompts[1].Count() > 0) || (_ai._chatReponses[1].Count() > 0))
-				UpdateChat();
-		}
+
+		if ((_ai._userPrompts[1].Count > 0) || (_ai._chatReponses[1].Count > 0))
+			UpdateChat();
 	}
 
-	public void LoadChat(string name, string type, List<string> list, bool allowNotes)
+	private void LoadChatFile(string name, string type, List<string> list, bool allowNotes, bool allowContext)
 	{
-		string? str = Path.Combine(AppSettings.DocumentHome(), $"{type}s", name + ".txt");
-		string entryType = "";
-		string entry = "";
-		if (File.Exists(str))
-			using (StreamReader sr = File.OpenText(str))
+		string path = Path.Combine(AppSettings.DocumentHome(), $"{type}s", name + ".txt");
+		if (!File.Exists(path))
+		{
+			UpdateSessionLog("Failed to load " + path, true, true);
+			return;
+		}
+
+		string? currentSection = null;
+		StringBuilder buffer = new();
+
+		void FlushEntry()
+		{
+			if (string.IsNullOrEmpty(currentSection))
+				return;
+
+			string entry = buffer.ToString().TrimEnd('\n');
+			buffer.Clear();
+
+			if (string.IsNullOrEmpty(entry))
+				return;
+
+			if (currentSection == type)
+				list.Add(entry);
+			else if (currentSection == "Note" && allowNotes)
+				_sessionNotes.Add(entry);
+			else if (currentSection == "Context" && allowContext)
+				SetContextSessions(entry);
+		}
+
+		using StreamReader sr = File.OpenText(path);
+		string? line;
+		while ((line = sr.ReadLine()) != null)
+		{
+			if (string.IsNullOrWhiteSpace(line))
+				continue;
+
+			if (line.StartsWith("$(") && line.EndsWith(")"))
 			{
-				while ((str = sr.ReadLine()) != null)
-				{
-					if (string.IsNullOrEmpty(str))
-						continue;
-
-					if (entryType == "Context")
-					{
-						entryType = "";
-						entry = "";
-						if (!str.StartsWith("$("))
-							continue;
-					}
-
-					if (str == "$(Context)")
-					{
-						if (!string.IsNullOrEmpty(entry))
-						{
-							if (!string.IsNullOrEmpty(entryType) && (entryType == type))
-								list.Add(entry);
-							else if (allowNotes)
-								_sessionNotes.Add(entry);
-							entry = "";
-						}
-						entryType = "Context";
-						continue;
-					}
-					if (str == $"$({type})")
-					{
-						if (!string.IsNullOrEmpty(entry))
-						{
-							if (!string.IsNullOrEmpty(entryType) && (entryType == type))
-								list.Add(entry);
-							else if (allowNotes)
-								_sessionNotes.Add(entry);
-							entry = "";
-						}
-						entryType = type;
-					}
-					else if (str == $"$(Note)")
-					{
-						if (!string.IsNullOrEmpty(entry))
-						{
-							if (!string.IsNullOrEmpty(entryType) && (entryType == type))
-								list.Add(entry);
-							else if (allowNotes)
-								_sessionNotes.Add(entry);
-							entry = "";
-						}
-						entryType = "Note";
-					}
-					else
-						entry += str + "\n";
-				}
-
-				if (!string.IsNullOrEmpty(entry))
-					if (!string.IsNullOrEmpty(entryType) && (entryType == type))
-						list.Add(entry);
-					else if (allowNotes)
-						_sessionNotes.Add(entry);
+				FlushEntry();
+				currentSection = line[2..^1];
+				continue;
 			}
-		else
-			UpdateSessionLog("Failed to load " + str, true, true);
+
+			buffer.AppendLine(line);
+		}
+
+		FlushEntry();
 	}
 
 	public async Task NavigateToDialogPage()

--- a/Yijing.maui/Yijing.maui.csproj
+++ b/Yijing.maui/Yijing.maui.csproj
@@ -98,7 +98,7 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Plugin.Maui.Audio" Version="4.0.0" />
 		<PackageReference Include="LiveChartsCore.SkiaSharpView.Maui" Version="2.0.0-rc5.4" />
-		<PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.264">
+		<PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.269">
 			<PrivateAssets>all</PrivateAssets>
 			<!--IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets-->
 		</PackageReference>


### PR DESCRIPTION
### Motivation

- Reduce duplicated logic by merging `LoadContextSessions` and `LoadChat` into a single workflow to simplify session loading and context handling.
- Make file parsing more robust and easier to extend by switching to a section-based parser that unifies contexts, notes, and entries.

### Description

- Replaced the previous `LoadContextSessions`/`LoadChat` flow with `LoadChatSessionData(string session)` and a new section parser `LoadChatFile(string name, string type, List<string> list, bool allowNotes, bool allowContext)` in `Yijing.maui/Views/SessionView.xaml.cs`.
- `LoadChatSessionData` now resets `_ai._contextSessions`, loads the main session `Question` and `Answer` sections, calls `SortContextSessions()` and `UpdateContextSelectionFlags()`, then loads any referenced context sessions into the active prompt/response lists, and calls `UpdateChat()` when appropriate.
- The new `LoadChatFile` implements a single-pass section parser using a `StringBuilder` buffer, a `currentSection` marker, and a local `FlushEntry()` helper to record entries into the right bucket (`type`, `Note`, or `Context`) when it encounters markers like `$(Context)` / `$(Note)` / `$(Question)` / `$(Answer)`.
- Updated callers to use `LoadChatSessionData` (`LoadSelectedSession` and `EnsureContextSessionsLoadedForChat`) and improved failure logging to include the full `path` when a file is missing.

### Testing

- No automated tests were run as part of this change.
- A commit was created with the refactor applied to `Yijing.maui/Views/SessionView.xaml.cs` and the change set was recorded successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dcde12080832b9548a75d283073ec)