### PR TITLE
Replace Fixed Range with Trigger Hunter delay and wire MindCast to honor it

### DIFF
--- a/Yijing.maui/Services/AppPreferences.cs
+++ b/Yijing.maui/Services/AppPreferences.cs
@@ -26,6 +26,7 @@ public enum eChartTime { eTwoAndHalf, eFive };
 public enum eTriggerBand { eDelta, eTheta, eAlpha, eBeta, eGamma };
 public enum eTriggerChannel { eBackLeft, eFrontLeft, eBackCenter, eFrontRight, eBackRight };
 public enum eTriggerRange { eZeroOne, eOneTwo, eTwoThree, eTwoFour, eThreeFour, eThreeFive, eFourFive, eFourSix };
+public enum eTriggerHunter { eNone, eOne, eTwo, eThree, eFour, eFive, eSix, eSeven, eEight, eNine, eTen };
 
 public enum eAiService { eOpenAi, eDeepseek, eGithub, eOllama, eNone };
 public enum eAiEegMlModel { eStephenV, eNone }; // eJohnD
@@ -76,8 +77,7 @@ public static class AppPreferences
 		TriggerBand = Preferences.Get("TriggerBand", (int)eTriggerBand.eGamma);
 		TriggerChannel = Preferences.Get("TriggerChannel", (int)eTriggerChannel.eFrontLeft);
 		TriggerRange = Preferences.Get("TriggerRange", (int)eTriggerRange.eTwoFour);
-
-		TriggerFixed = Preferences.Get("TriggerFixed", false);
+		TriggerHunter = Preferences.Get("TriggerHunter", (int)eTriggerHunter.eFive);
 		TriggerSounding = Preferences.Get("TriggerSounding", true);
 		RawData = Preferences.Get("RawData", false);
 
@@ -225,7 +225,7 @@ public static class AppPreferences
 	public static int TriggerChannel;
 	public static int TriggerRange;
 
-	public static bool TriggerFixed;
+	public static int TriggerHunter;
 	public static bool TriggerSounding;
 	public static bool RawData;
 

--- a/Yijing.maui/Views/DiagramView.xaml.cs
+++ b/Yijing.maui/Views/DiagramView.xaml.cs
@@ -1202,6 +1202,9 @@ public partial class DiagramView : ContentView
 			const float triggerChangeTarget = 0.1f;
 			float rampProgress = 0.0f;
 			float lastChange = 0.0f;
+			int hunterDelayMinutes = AppPreferences.TriggerHunter;
+			DateTime hunterStart = DateTime.Now;
+			bool hunterActive = false;
 
 			int count = 0;
 			//App.EegSetTriggers(true, true);
@@ -1212,12 +1215,30 @@ public partial class DiagramView : ContentView
 					SoundTrigger(ev.EegChannel(AppPreferences.TriggerIndex).m_fCurrentValue * AppPreferences.AudioScale,
 					ev.EegChannel(AppPreferences.TriggerIndex).m_fHigh * AppPreferences.AudioScale);
 				DateTime now = DateTime.Now;
-				rampProgress += (float)(now - lastUpdate).TotalSeconds;
-				lastUpdate = now;
-				int speed = m_nTriggerSpeed * ev.EegReplaySpeed();
-				speed = speed > 50 ? 50 : speed;
-				if (!AppPreferences.TriggerFixed)
+				int currentHunterDelay = AppPreferences.TriggerHunter;
+				if (currentHunterDelay != hunterDelayMinutes)
 				{
+					hunterDelayMinutes = currentHunterDelay;
+					hunterStart = now;
+					hunterActive = false;
+					rampProgress = 0.0f;
+					lastChange = 0.0f;
+					lastUpdate = now;
+				}
+				bool hunterEnabled = hunterDelayMinutes > 0;
+				if (hunterEnabled && !hunterActive && (now - hunterStart).TotalMinutes >= hunterDelayMinutes)
+				{
+					hunterActive = true;
+					rampProgress = 0.0f;
+					lastChange = 0.0f;
+					lastUpdate = now;
+				}
+				if (hunterEnabled && hunterActive)
+				{
+					rampProgress += (float)(now - lastUpdate).TotalSeconds;
+					lastUpdate = now;
+					int speed = m_nTriggerSpeed * ev.EegReplaySpeed();
+					speed = speed > 50 ? 50 : speed;
 					float progress = (float)(rampProgress * speed / 60.0f);
 					float change = triggerChangeTarget * ((float)Math.Exp(progress) - 1.0f);
 					float delta = change - lastChange;
@@ -1225,6 +1246,8 @@ public partial class DiagramView : ContentView
 						ev.EegDecreaseTriggers(delta);
 					lastChange = change;
 				}
+				else
+					lastUpdate = now;
 			}
 			if (!ev.EegIsConnected())
 				break;
@@ -1236,6 +1259,9 @@ public partial class DiagramView : ContentView
 			lastUpdate = DateTime.Now;
 			rampProgress = 0.0f;
 			lastChange = 0.0f;
+			hunterDelayMinutes = AppPreferences.TriggerHunter;
+			hunterStart = DateTime.Now;
+			hunterActive = false;
 
 			count = 0;
 			//App.EegSetTriggers(true, false);
@@ -1246,12 +1272,30 @@ public partial class DiagramView : ContentView
 					SoundTrigger(ev.EegChannel(AppPreferences.TriggerIndex).m_fCurrentValue * AppPreferences.AudioScale,
 					ev.EegChannel(AppPreferences.TriggerIndex).m_fLow * AppPreferences.AudioScale);
 				DateTime now = DateTime.Now;
-				rampProgress += (float)(now - lastUpdate).TotalSeconds;
-				lastUpdate = now;
-				int speed = m_nTriggerSpeed * ev.EegReplaySpeed();
-				speed = speed > 50 ? 50 : speed;
-				if (!AppPreferences.TriggerFixed)
+				int currentHunterDelay = AppPreferences.TriggerHunter;
+				if (currentHunterDelay != hunterDelayMinutes)
 				{
+					hunterDelayMinutes = currentHunterDelay;
+					hunterStart = now;
+					hunterActive = false;
+					rampProgress = 0.0f;
+					lastChange = 0.0f;
+					lastUpdate = now;
+				}
+				bool hunterEnabled = hunterDelayMinutes > 0;
+				if (hunterEnabled && !hunterActive && (now - hunterStart).TotalMinutes >= hunterDelayMinutes)
+				{
+					hunterActive = true;
+					rampProgress = 0.0f;
+					lastChange = 0.0f;
+					lastUpdate = now;
+				}
+				if (hunterEnabled && hunterActive)
+				{
+					rampProgress += (float)(now - lastUpdate).TotalSeconds;
+					lastUpdate = now;
+					int speed = m_nTriggerSpeed * ev.EegReplaySpeed();
+					speed = speed > 50 ? 50 : speed;
 					float progress = (float)(rampProgress * speed / 60.0f);
 					float change = triggerChangeTarget * ((float)Math.Exp(progress) - 1.0f);
 					float delta = change - lastChange;
@@ -1259,6 +1303,8 @@ public partial class DiagramView : ContentView
 						ev.EegIncreaseTriggers(delta);
 					lastChange = change;
 				}
+				else
+					lastUpdate = now;
 			}
 
 			//App.EegCalculateTriggers();

--- a/Yijing.maui/Views/DiagramView.xaml.cs
+++ b/Yijing.maui/Views/DiagramView.xaml.cs
@@ -1207,7 +1207,7 @@ public partial class DiagramView : ContentView
 			}
 			if (hunterDelayMinutes <= 0)
 				return false;
-			double elapsedMinutes = (now - hunterStart).TotalMinutes * ev.EegReplaySpeed();
+			double elapsedMinutes = (now - hunterStart).TotalMinutes;
 			if (!hunterActive && elapsedMinutes >= hunterDelayMinutes)
 			{
 				hunterActive = true;

--- a/Yijing.maui/Views/DiagramView.xaml.cs
+++ b/Yijing.maui/Views/DiagramView.xaml.cs
@@ -1222,6 +1222,9 @@ public partial class DiagramView : ContentView
 			SetCurrentLine(i, true);
 			UpdateDiagram(false);
 
+			hunterStart = DateTime.Now;
+			hunterActive = false;
+
 			//App.EegChannel(AppPreferences.TriggerIndex).m_fMinValue = 1000.0f;
 			//App.EegChannel(AppPreferences.TriggerIndex).m_fMaxValue = -1000.0f;
 

--- a/Yijing.maui/Views/DiagramView.xaml.cs
+++ b/Yijing.maui/Views/DiagramView.xaml.cs
@@ -1207,7 +1207,9 @@ public partial class DiagramView : ContentView
 			}
 			if (hunterDelayMinutes <= 0)
 				return false;
-			double elapsedMinutes = (now - hunterStart).TotalMinutes;
+			int replaySpeed = ev.EegReplaySpeed();
+			replaySpeed = replaySpeed <= 0 ? 1 : replaySpeed;
+			double elapsedMinutes = (now - hunterStart).TotalMinutes * replaySpeed;
 			if (!hunterActive && elapsedMinutes >= hunterDelayMinutes)
 			{
 				hunterActive = true;

--- a/Yijing.maui/Views/DiagramView.xaml.cs
+++ b/Yijing.maui/Views/DiagramView.xaml.cs
@@ -1207,7 +1207,8 @@ public partial class DiagramView : ContentView
 			}
 			if (hunterDelayMinutes <= 0)
 				return false;
-			if (!hunterActive && (now - hunterStart).TotalMinutes >= hunterDelayMinutes)
+			double elapsedMinutes = (now - hunterStart).TotalMinutes * ev.EegReplaySpeed();
+			if (!hunterActive && elapsedMinutes >= hunterDelayMinutes)
 			{
 				hunterActive = true;
 				rampProgress = 0.0f;

--- a/Yijing.maui/Views/DiagramView.xaml.cs
+++ b/Yijing.maui/Views/DiagramView.xaml.cs
@@ -1270,6 +1270,9 @@ public partial class DiagramView : ContentView
 
 			m_timDiagram.Change(0, m_nSpeeds[(int)eDiagramSpeed.eFast]);
 
+			hunterStart = DateTime.Now;
+			hunterActive = false;
+
 			lastUpdate = DateTime.Now;
 			rampProgress = 0.0f;
 			lastChange = 0.0f;

--- a/Yijing.maui/Views/EegView.xaml
+++ b/Yijing.maui/Views/EegView.xaml
@@ -302,8 +302,8 @@
 				</Picker>
 
 				<Label 
-					x:Name="lblAiAnalysis"
-					Text="AI Analysis"
+					x:Name="lblTriggerHunter"
+					Text="Trigger Hunter"
 					LineBreakMode="TailTruncation"
 					VerticalTextAlignment="Center"
 					Grid.Column="0"
@@ -311,10 +311,40 @@
 					/>
 
 				<Picker
+					x:Name="picTriggerHunter"
+					SelectedIndexChanged="picTriggerHunter_SelectedIndexChanged"
+					Grid.Column="1"
+					Grid.Row="12"
+					>
+					<Picker.Items>
+						<x:String>None</x:String>
+						<x:String>1 Minute</x:String>
+						<x:String>2 Minutes</x:String>
+						<x:String>3 Minutes</x:String>
+						<x:String>4 Minutes</x:String>
+						<x:String>5 Minutes</x:String>
+						<x:String>6 Minutes</x:String>
+						<x:String>7 Minutes</x:String>
+						<x:String>8 Minutes</x:String>
+						<x:String>9 Minutes</x:String>
+						<x:String>10 Minutes</x:String>
+					</Picker.Items>
+				</Picker>
+
+				<Label 
+					x:Name="lblAiAnalysis"
+					Text="AI Analysis"
+					LineBreakMode="TailTruncation"
+					VerticalTextAlignment="Center"
+					Grid.Column="0"
+					Grid.Row="13"
+					/>
+
+				<Picker
 					x:Name="picAiAnalysis"
 					SelectedIndexChanged="picAiAnalysis_SelectedIndexChanged"
 					Grid.Column="1"
-					Grid.Row="12"
+					Grid.Row="13"
 					>
 					<Picker.Items>
 						<x:String>OpenAi</x:String>
@@ -331,36 +361,20 @@
 					LineBreakMode="TailTruncation"
 					VerticalTextAlignment="Center"
 					Grid.Column="0"
-					Grid.Row="13"
+					Grid.Row="14"
 					/>
 
 				<Picker
 					x:Name="picAiModel"
 					SelectedIndexChanged="picAiModel_SelectedIndexChanged"
 					Grid.Column="1"
-					Grid.Row="13"
+					Grid.Row="14"
 					>
 					<Picker.Items>
 						<x:String>Stephen V</x:String>
 						<x:String>None</x:String>
 					</Picker.Items>
 				</Picker>
-
-				<Label 
-					x:Name="lblTriggerFixed"
-					Text="Fixed Range"
-					LineBreakMode="TailTruncation"
-					VerticalTextAlignment="Center"
-					Grid.Column="0"
-					Grid.Row="14"
-					/>
-
-				<CheckBox 
-					x:Name="chbTriggerFixed"
-					CheckedChanged="chbTriggerFixed_CheckedChanged"
-					Grid.Column="1"
-					Grid.Row="14"
-					/>
 
 				<Label 
 					x:Name="lblTriggerSounding"

--- a/Yijing.maui/Views/EegView.xaml.cs
+++ b/Yijing.maui/Views/EegView.xaml.cs
@@ -72,9 +72,9 @@ public partial class EegView : ContentView
 		picTriggerBand.SelectedIndex = AppPreferences.TriggerBand;
 		picTriggerChannel.SelectedIndex = AppPreferences.TriggerChannel;
 		picTriggerRange.SelectedIndex = AppPreferences.TriggerRange;
+		picTriggerHunter.SelectedIndex = AppPreferences.TriggerHunter;
 		picAiAnalysis.SelectedIndex = AppPreferences.AiEegService;
 		picAiModel.SelectedIndex = AppPreferences.AiEegMlModel;
-		chbTriggerFixed.IsChecked = AppPreferences.TriggerFixed;
 		chbTriggerSounding.IsChecked = AppPreferences.TriggerSounding;
 
 		//_ai.AddSystemMessage(
@@ -130,7 +130,7 @@ public partial class EegView : ContentView
 		lblAiAnalysis.WidthRequest = w;
 		lblAiModel.WidthRequest = w;
 		lblTriggerRange.WidthRequest = w;
-		lblTriggerFixed.WidthRequest = w;
+		lblTriggerHunter.WidthRequest = w;
 		lblTriggerSounding.WidthRequest = w;
 		lblRawData.WidthRequest = w;
 
@@ -148,7 +148,7 @@ public partial class EegView : ContentView
 		picAiAnalysis.WidthRequest = w;
 		picAiModel.WidthRequest = w;
 		picTriggerRange.WidthRequest = w;
-		chbTriggerFixed.WidthRequest = w;
+		picTriggerHunter.WidthRequest = w;
 		chbTriggerSounding.WidthRequest = w;
 		chbRawData.WidthRequest = w;
 
@@ -326,6 +326,11 @@ public partial class EegView : ContentView
 		_eeg.m_eegChannel[AppPreferences.TriggerIndex].m_fDifference = _eeg.m_eegChannel[AppPreferences.TriggerIndex].m_fInitialHigh - _eeg.m_eegChannel[AppPreferences.TriggerIndex].m_fInitialLow;
 	}
 
+	private void picTriggerHunter_SelectedIndexChanged(object sender, EventArgs e)
+	{
+		AppPreferences.TriggerHunter = picTriggerHunter.SelectedIndex;
+	}
+
 	private void picAiAnalysis_SelectedIndexChanged(object sender, EventArgs e)
 	{
 		AppPreferences.AiEegService = picAiAnalysis.SelectedIndex;
@@ -338,12 +343,6 @@ public partial class EegView : ContentView
 	private void picAiModel_SelectedIndexChanged(object sender, EventArgs e)
 	{
 		AppPreferences.AiEegMlModel = picAiModel.SelectedIndex;
-	}
-
-	private void chbTriggerFixed_CheckedChanged(object sender, EventArgs e)
-	{
-		if (chbTriggerFixed is not null)
-			AppPreferences.TriggerFixed = chbTriggerFixed.IsChecked;
 	}
 
 	private void chbTriggerSounding_CheckedChanged(object sender, EventArgs e)
@@ -497,7 +496,7 @@ public partial class EegView : ContentView
 		void action1() => picReplaySpeed.IsEnabled = bEnable;
 		void action2() => picTriggerChannel.IsEnabled = bEnable;
 		void action3() => picTriggerRange.IsEnabled = bEnable;
-		void action4() => chbTriggerFixed.IsEnabled = bEnable;
+		void action4() => picTriggerHunter.IsEnabled = bEnable;
 
 		if (bEnable)
 		{


### PR DESCRIPTION
### Motivation
- Replace the old boolean `TriggerFixed` control with a user-configurable trigger-hunter delay so the trigger ramping can be deferred and adjusted during a session.
- Make the delay selectable in the EEG settings and use it from the diagram `MindCast` flow to control when the hunter starts ramping triggers.

### Description
- Introduced an `eTriggerHunter` enum (`eNone`, `eOne` .. `eTen`) and replaced the `bool TriggerFixed` with an `int TriggerHunter` preference in `AppPreferences` with the default set to `eFive` (5 minutes) via `Preferences.Get("TriggerHunter", (int)eTriggerHunter.eFive)`.
- Replaced the `Fixed Range` checkbox in the EEG settings UI with a `picTriggerHunter` `Picker` (`Yijing.maui/Views/EegView.xaml`) offering `None` and `1..10 Minutes`, wired to `picTriggerHunter_SelectedIndexChanged` which sets `AppPreferences.TriggerHunter` and added sizing/initialization updates in `EegView.xaml.cs`.
- Updated `DiagramView.MindCast` to introduce `hunterDelayMinutes`, `hunterStart` and `hunterActive` state and only run the trigger ramping logic after the selected delay elapses, while also responding to changes to `AppPreferences.TriggerHunter` during a session so the hunter delay resets dynamically.
- Removed references to the old `TriggerFixed` usage and ensured the decrease/increase ramp logic is gated by the hunter enable/active state in both trigger-on and trigger-off loops.

### Testing
- No automated tests were executed as part of this change set (no unit/integration tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ed7272d30832ba2d3af43e5a37238)