### PR TITLE
Add trigger schedule and adaptive hunter feedback

### DIFF
--- a/Yijing.maui/Services/AppPreferences.cs
+++ b/Yijing.maui/Services/AppPreferences.cs
@@ -27,7 +27,7 @@ public enum eTriggerBand { eDelta, eTheta, eAlpha, eBeta, eGamma };
 public enum eTriggerChannel { eBackLeft, eFrontLeft, eBackCenter, eFrontRight, eBackRight };
 public enum eTriggerRange { eZeroOne, eOneTwo, eTwoThree, eTwoFour, eThreeFour, eThreeFive, eFourFive, eFourSix };
 public enum eTriggerHunter { eNone, eOne, eTwo, eThree, eFour, eFive, eSix, eSeven, eEight, eNine, eTen };
-public enum eTriggerSchedule { eTwenty, eThirty, eFourty, eSixty, eNinety, eOneTwenty };
+public enum eTriggerSchedule { eTwenty, eThirty, eForty, eSixty, eNinety, eOneTwenty };
 
 public enum eAiService { eOpenAi, eDeepseek, eGithub, eOllama, eNone };
 public enum eAiEegMlModel { eStephenV, eNone }; // eJohnD
@@ -69,7 +69,7 @@ public static class AppPreferences
 		EegDevice = Preferences.Get("EegDevice", (int)eEegDevice.eMuse);
 		EegGoal = Preferences.Get("EegGoal", (int)eGoal.eYijingCast);
 		Ambience = Preferences.Get("Ambience", (int)eAmbience.eLightRain);
-		Timer = Preferences.Get("Timer", (int)eTimer.eTen);
+		Timer = Preferences.Get("Timer", (int)eTimer.eTwenty);
 
 		ReplaySpeed = Preferences.Get("ReplaySpeed", (int)eReplaySpeed.eNormal);
 		ChartBands = Preferences.Get("ChartBands", (int)eChartBands.eFront);

--- a/Yijing.maui/Services/AppPreferences.cs
+++ b/Yijing.maui/Services/AppPreferences.cs
@@ -27,6 +27,7 @@ public enum eTriggerBand { eDelta, eTheta, eAlpha, eBeta, eGamma };
 public enum eTriggerChannel { eBackLeft, eFrontLeft, eBackCenter, eFrontRight, eBackRight };
 public enum eTriggerRange { eZeroOne, eOneTwo, eTwoThree, eTwoFour, eThreeFour, eThreeFive, eFourFive, eFourSix };
 public enum eTriggerHunter { eNone, eOne, eTwo, eThree, eFour, eFive, eSix, eSeven, eEight, eNine, eTen };
+public enum eTriggerSchedule { eTwenty, eThirty, eFourty, eSixty, eNinety, eOneTwenty };
 
 public enum eAiService { eOpenAi, eDeepseek, eGithub, eOllama, eNone };
 public enum eAiEegMlModel { eStephenV, eNone }; // eJohnD
@@ -78,6 +79,7 @@ public static class AppPreferences
 		TriggerChannel = Preferences.Get("TriggerChannel", (int)eTriggerChannel.eFrontLeft);
 		TriggerRange = Preferences.Get("TriggerRange", (int)eTriggerRange.eTwoFour);
 		TriggerHunter = Preferences.Get("TriggerHunter", (int)eTriggerHunter.eFive);
+		TriggerSchedule = Preferences.Get("TriggerSchedule", (int)eTriggerSchedule.eSixty);
 		TriggerSounding = Preferences.Get("TriggerSounding", true);
 		RawData = Preferences.Get("RawData", false);
 
@@ -226,6 +228,7 @@ public static class AppPreferences
 	public static int TriggerRange;
 
 	public static int TriggerHunter;
+	public static int TriggerSchedule;
 	public static bool TriggerSounding;
 	public static bool RawData;
 

--- a/Yijing.maui/Views/DiagramView.xaml.cs
+++ b/Yijing.maui/Views/DiagramView.xaml.cs
@@ -1187,11 +1187,48 @@ public partial class DiagramView : ContentView
 		EegView ev = UI.Get<EegView>();
 		ev.EegSetTriggers(true, true);
 		int hunterDelayMinutes = AppPreferences.TriggerHunter;
+		DateTime castStart = DateTime.Now;
 		DateTime hunterStart = DateTime.Now;
 		bool hunterActive = false;
 		DateTime lastUpdate = DateTime.Now;
 		float rampProgress = 0.0f;
 		float lastChange = 0.0f;
+		const double scheduleTolerance = 0.10;
+		int ScheduleMinutes()
+		{
+			return AppPreferences.TriggerSchedule switch
+			{
+				(int)eTriggerSchedule.eTwenty => 20,
+				(int)eTriggerSchedule.eThirty => 30,
+				(int)eTriggerSchedule.eFourty => 40,
+				(int)eTriggerSchedule.eSixty => 60,
+				(int)eTriggerSchedule.eNinety => 90,
+				(int)eTriggerSchedule.eOneTwenty => 120,
+				_ => 60
+			};
+		}
+		void AdjustTriggerHunterForSchedule(int lineIndex)
+		{
+			int scheduleMinutes = ScheduleMinutes();
+			if (scheduleMinutes <= 0)
+				return;
+			int replaySpeed = ev.EegReplaySpeed();
+			replaySpeed = replaySpeed <= 0 ? 1 : replaySpeed;
+			double elapsedMinutes = (DateTime.Now - castStart).TotalMinutes * replaySpeed;
+			double targetMinutes = scheduleMinutes * (lineIndex + 1) / 6.0;
+			if (targetMinutes <= 0.0)
+				return;
+			double minTarget = targetMinutes * (1.0 - scheduleTolerance);
+			double maxTarget = targetMinutes * (1.0 + scheduleTolerance);
+			int newHunterDelay = AppPreferences.TriggerHunter;
+			if (elapsedMinutes > maxTarget)
+				newHunterDelay = Math.Max(0, newHunterDelay - 1);
+			else
+			if (elapsedMinutes < minTarget)
+				newHunterDelay = Math.Min((int)eTriggerHunter.eTen, newHunterDelay + 1);
+			if (newHunterDelay != AppPreferences.TriggerHunter)
+				ev.UpdateTriggerHunter(newHunterDelay);
+		}
 		bool ShouldRamp(DateTime now)
 		{
 			int currentHunterDelay = AppPreferences.TriggerHunter;
@@ -1297,6 +1334,7 @@ public partial class DiagramView : ContentView
 				break;
 			if (AppPreferences.TriggerSounding)
 				SoundTrigger(ev.EegChannel(AppPreferences.TriggerIndex).m_fCurrentValue * AppPreferences.AudioScale, 0.0f);
+			AdjustTriggerHunterForSchedule(i);
 		}
 		await Task.Delay(100);
 		AudioPlayer.PlayHexagramEnd(Dispatcher);

--- a/Yijing.maui/Views/DiagramView.xaml.cs
+++ b/Yijing.maui/Views/DiagramView.xaml.cs
@@ -1222,7 +1222,7 @@ public partial class DiagramView : ContentView
 			double maxTarget = targetMinutes * (1.0 + scheduleTolerance);
 			int newHunterDelay = AppPreferences.TriggerHunter;
 			if (elapsedMinutes > maxTarget)
-				newHunterDelay = Math.Max(0, newHunterDelay - 1);
+				newHunterDelay = Math.Max((int)eTriggerHunter.eOne, newHunterDelay - 1);
 			else
 			if (elapsedMinutes < minTarget)
 				newHunterDelay = Math.Min((int)eTriggerHunter.eTen, newHunterDelay + 1);

--- a/Yijing.maui/Views/DiagramView.xaml.cs
+++ b/Yijing.maui/Views/DiagramView.xaml.cs
@@ -1200,7 +1200,7 @@ public partial class DiagramView : ContentView
 			{
 				(int)eTriggerSchedule.eTwenty => 20,
 				(int)eTriggerSchedule.eThirty => 30,
-				(int)eTriggerSchedule.eFourty => 40,
+				(int)eTriggerSchedule.eForty => 40,
 				(int)eTriggerSchedule.eSixty => 60,
 				(int)eTriggerSchedule.eNinety => 90,
 				(int)eTriggerSchedule.eOneTwenty => 120,

--- a/Yijing.maui/Views/EegView.xaml
+++ b/Yijing.maui/Views/EegView.xaml
@@ -332,8 +332,8 @@
 				</Picker>
 
 				<Label 
-					x:Name="lblAiAnalysis"
-					Text="AI Analysis"
+					x:Name="lblTriggerSchedule"
+					Text="Trigger Schedule"
 					LineBreakMode="TailTruncation"
 					VerticalTextAlignment="Center"
 					Grid.Column="0"
@@ -341,10 +341,35 @@
 					/>
 
 				<Picker
+					x:Name="picTriggerSchedule"
+					SelectedIndexChanged="picTriggerSchedule_SelectedIndexChanged"
+					Grid.Column="1"
+					Grid.Row="13"
+					>
+					<Picker.Items>
+						<x:String>20 Minutes</x:String>
+						<x:String>30 Minutes</x:String>
+						<x:String>40 Minutes</x:String>
+						<x:String>60 Minutes</x:String>
+						<x:String>90 Minutes</x:String>
+						<x:String>120 Minutes</x:String>
+					</Picker.Items>
+				</Picker>
+
+				<Label 
+					x:Name="lblAiAnalysis"
+					Text="AI Analysis"
+					LineBreakMode="TailTruncation"
+					VerticalTextAlignment="Center"
+					Grid.Column="0"
+					Grid.Row="14"
+					/>
+
+				<Picker
 					x:Name="picAiAnalysis"
 					SelectedIndexChanged="picAiAnalysis_SelectedIndexChanged"
 					Grid.Column="1"
-					Grid.Row="13"
+					Grid.Row="14"
 					>
 					<Picker.Items>
 						<x:String>OpenAi</x:String>
@@ -361,14 +386,14 @@
 					LineBreakMode="TailTruncation"
 					VerticalTextAlignment="Center"
 					Grid.Column="0"
-					Grid.Row="14"
+					Grid.Row="15"
 					/>
 
 				<Picker
 					x:Name="picAiModel"
 					SelectedIndexChanged="picAiModel_SelectedIndexChanged"
 					Grid.Column="1"
-					Grid.Row="14"
+					Grid.Row="15"
 					>
 					<Picker.Items>
 						<x:String>Stephen V</x:String>
@@ -382,14 +407,14 @@
 					LineBreakMode="TailTruncation"
 					VerticalTextAlignment="Center"
 					Grid.Column="0"
-					Grid.Row="15"
+					Grid.Row="16"
 					/>
 
 				<CheckBox 
 					x:Name="chbTriggerSounding"
 					CheckedChanged="chbTriggerSounding_CheckedChanged"
 					Grid.Column="1"
-					Grid.Row="15"
+					Grid.Row="16"
 					/>
 
 				<Label 
@@ -398,14 +423,14 @@
 					LineBreakMode="TailTruncation"
 					VerticalTextAlignment="Center"
 					Grid.Column="0"
-					Grid.Row="16"
+					Grid.Row="17"
 					/>
 
 				<CheckBox 
 					x:Name="chbRawData"
 					CheckedChanged="chbRawData_CheckedChanged"
 					Grid.Column="1"
-					Grid.Row="16"
+					Grid.Row="17"
 					/>
 
 			</Grid>

--- a/Yijing.maui/Views/EegView.xaml.cs
+++ b/Yijing.maui/Views/EegView.xaml.cs
@@ -73,6 +73,7 @@ public partial class EegView : ContentView
 		picTriggerChannel.SelectedIndex = AppPreferences.TriggerChannel;
 		picTriggerRange.SelectedIndex = AppPreferences.TriggerRange;
 		picTriggerHunter.SelectedIndex = AppPreferences.TriggerHunter;
+		picTriggerSchedule.SelectedIndex = AppPreferences.TriggerSchedule;
 		picAiAnalysis.SelectedIndex = AppPreferences.AiEegService;
 		picAiModel.SelectedIndex = AppPreferences.AiEegMlModel;
 		chbTriggerSounding.IsChecked = AppPreferences.TriggerSounding;
@@ -131,6 +132,7 @@ public partial class EegView : ContentView
 		lblAiModel.WidthRequest = w;
 		lblTriggerRange.WidthRequest = w;
 		lblTriggerHunter.WidthRequest = w;
+		lblTriggerSchedule.WidthRequest = w;
 		lblTriggerSounding.WidthRequest = w;
 		lblRawData.WidthRequest = w;
 
@@ -149,6 +151,7 @@ public partial class EegView : ContentView
 		picAiModel.WidthRequest = w;
 		picTriggerRange.WidthRequest = w;
 		picTriggerHunter.WidthRequest = w;
+		picTriggerSchedule.WidthRequest = w;
 		chbTriggerSounding.WidthRequest = w;
 		chbRawData.WidthRequest = w;
 
@@ -331,6 +334,11 @@ public partial class EegView : ContentView
 		AppPreferences.TriggerHunter = picTriggerHunter.SelectedIndex;
 	}
 
+	private void picTriggerSchedule_SelectedIndexChanged(object sender, EventArgs e)
+	{
+		AppPreferences.TriggerSchedule = picTriggerSchedule.SelectedIndex;
+	}
+
 	private void picAiAnalysis_SelectedIndexChanged(object sender, EventArgs e)
 	{
 		AppPreferences.AiEegService = picAiAnalysis.SelectedIndex;
@@ -497,6 +505,7 @@ public partial class EegView : ContentView
 		void action2() => picTriggerChannel.IsEnabled = bEnable;
 		void action3() => picTriggerRange.IsEnabled = bEnable;
 		void action4() => picTriggerHunter.IsEnabled = bEnable;
+		void action5() => picTriggerSchedule.IsEnabled = bEnable;
 
 		if (bEnable)
 		{
@@ -504,6 +513,7 @@ public partial class EegView : ContentView
 			Dispatcher.Dispatch(action2);
 			Dispatcher.Dispatch(action3);
 			Dispatcher.Dispatch(action4);
+			Dispatcher.Dispatch(action5);
 		}
 		//else
 		//if (bLive)
@@ -704,5 +714,15 @@ public partial class EegView : ContentView
 	public EegChannel EegChannel(int index)
 	{
 		return _eeg.m_eegChannel[index];
+	}
+
+	public void UpdateTriggerHunter(int hunterDelay)
+	{
+		void action()
+		{
+			AppPreferences.TriggerHunter = hunterDelay;
+			picTriggerHunter.SelectedIndex = hunterDelay;
+		}
+		Dispatcher.Dispatch(action);
 	}
 }

--- a/Yijing.maui/Views/EegView.xaml.cs
+++ b/Yijing.maui/Views/EegView.xaml.cs
@@ -720,8 +720,9 @@ public partial class EegView : ContentView
 	{
 		void action()
 		{
-			AppPreferences.TriggerHunter = hunterDelay;
-			picTriggerHunter.SelectedIndex = hunterDelay;
+			int clampedDelay = Math.Clamp(hunterDelay, (int)eTriggerHunter.eOne, (int)eTriggerHunter.eTen);
+			AppPreferences.TriggerHunter = clampedDelay;
+			picTriggerHunter.SelectedIndex = clampedDelay;
 		}
 		Dispatcher.Dispatch(action);
 	}


### PR DESCRIPTION
### Motivation
- Introduce a user-selectable trigger schedule and a small feedback controller so line timing converges to a target schedule during `MindCast` runs.
- Allow the UI to present a `Trigger Schedule` picker and update the `Trigger Hunter` delay dynamically so each of the six lines aims for its 1/6th schedule timeframe.

### Description
- Add a new enum `eTriggerSchedule` and an `TriggerSchedule` preference in `AppPreferences.cs`, with a default mapping to `eSixty`.
- Add a `Trigger Schedule` `Picker` to `EegView.xaml` and wire it to `picTriggerSchedule_SelectedIndexChanged`, initialize `picTriggerSchedule.SelectedIndex` from `AppPreferences.TriggerSchedule`, and include sizing and enable/disable handling in `EegView.xaml.cs`.
- Expose `EegView.UpdateTriggerHunter(int)` to update both `AppPreferences.TriggerHunter` and the `picTriggerHunter` UI control from other components.
- Implement a feedback controller in `DiagramView.xaml.cs` inside `MindCast()` that records `castStart`, maps the chosen schedule to minutes, computes the per-line target (1/6th per line) with a 10% tolerance, compares elapsed time to the target after each line, and nudges `TriggerHunter` by -1 when behind or +1 when ahead, calling `ev.UpdateTriggerHunter()` when a change is needed.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972b9d2a0d0832ba5ba8b08d5cc5269)