### PR TITLE
Persist AppPreferences on exit and centralize preference keys

### DIFF
--- a/Yijing.maui/App.xaml.cs
+++ b/Yijing.maui/App.xaml.cs
@@ -1,5 +1,6 @@
 using LiveChartsCore;
 using LiveChartsCore.SkiaSharpView;
+using Yijing.Services;
 
 namespace Yijing;
 
@@ -30,6 +31,7 @@ public partial class App : Application
 	{
 		//Window window = base.CreateWindow(activationState);
 		Window window = new Window(new AppShell());
+		window.Destroying += (s, e) => AppPreferences.Save();
 		window.Created += (s, e) =>
 		{
 			//window.X = 100;

--- a/Yijing.maui/Services/AppPreferences.cs
+++ b/Yijing.maui/Services/AppPreferences.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Configuration;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
-using ValueSequencer;
 using YijingData;
 
 namespace Yijing.Services;
@@ -71,52 +70,87 @@ public static class AppPreferences
 	public const string AiEegServiceKey = "AiEegService";
 	public const string AiEegMlModelKey = "AiEegMlModel";
 
+	public const int DiagramLsbDefault = 1;
+	public const int DiagramModeDefault = (int)eDiagramMode.eExplore;
+	public const int DiagramTypeDefault = (int)eDiagramType.eHexagram;
+	public const int DiagramColorDefault = (int)eDiagramColor.eTrigram;
+	public const int DiagramSpeedDefault = (int)eDiagramSpeed.eMedium;
+	public const int HexagramTextDefault = 1;
+	public const int HexagramLabelDefault = 9;
+	public const int HexagramSequenceDefault = 2;
+	public const int HexagramRatioDefault = 0;
+	public const int TrigramTextDefault = 0;
+	public const int TrigramLabelDefault = 2;
+	public const int TrigramSequenceDefault = 1;
+	public const int TrigramRatioDefault = 0;
+	public const int LineTextDefault = 0;
+	public const int LineLabelDefault = 3;
+	public const int LineSequenceDefault = 1;
+	public const int LineRatioDefault = 1;
+	public const int EegDeviceDefault = (int)eEegDevice.eMuse;
+	public const int EegGoalDefault = (int)eGoal.eYijingCast;
+	public const int AmbienceDefault = (int)eAmbience.eLightRain;
+	public const int TimerDefault = (int)eTimer.eTwenty;
+	public const int ReplaySpeedDefault = (int)eReplaySpeed.eNormal;
+	public const int ChartBandsDefault = (int)eChartBands.eFront;
+	public const int ChartTimeDefault = (int)eChartTime.eTwoAndHalf;
+	public const int TriggerBandDefault = (int)eTriggerBand.eGamma;
+	public const int TriggerChannelDefault = (int)eTriggerChannel.eFrontLeft;
+	public const int TriggerRangeDefault = (int)eTriggerRange.eTwoFour;
+	public const int TriggerHunterDefault = (int)eTriggerHunter.eFive;
+	public const int TriggerScheduleDefault = (int)eTriggerSchedule.eSixty;
+	public const bool TriggerSoundingDefault = true;
+	public const bool RawDataDefault = false;
+	public const int AiChatServiceDefault = (int)eAiService.eNone;
+	public const int AiEegServiceDefault = (int)eAiService.eNone;
+	public const int AiEegMlModelDefault = (int)eAiEegMlModel.eNone;
+
 	public static void Load()
 	{
 
-		DiagramLsb = Preferences.Get(DiagramLsbKey, Sequences.DiagramLsb);
+		DiagramLsb = Preferences.Get(DiagramLsbKey, DiagramLsbDefault);
 
-		DiagramMode = Preferences.Get(DiagramModeKey, (int)eDiagramMode.eExplore);
-		DiagramType = Preferences.Get(DiagramTypeKey, (int)eDiagramType.eHexagram);
-		DiagramColor = Preferences.Get(DiagramColorKey, (int)eDiagramColor.eTrigram);
-		DiagramSpeed = Preferences.Get(DiagramSpeedKey, (int)eDiagramSpeed.eMedium);
+		DiagramMode = Preferences.Get(DiagramModeKey, DiagramModeDefault);
+		DiagramType = Preferences.Get(DiagramTypeKey, DiagramTypeDefault);
+		DiagramColor = Preferences.Get(DiagramColorKey, DiagramColorDefault);
+		DiagramSpeed = Preferences.Get(DiagramSpeedKey, DiagramSpeedDefault);
 
-		HexagramText = Preferences.Get(HexagramTextKey, Sequences.HexagramText);
-		HexagramLabel = Preferences.Get(HexagramLabelKey, Sequences.HexagramLabel);
-		HexagramSequence = Preferences.Get(HexagramSequenceKey, Sequences.HexagramSequence);
-		HexagramRatio = Preferences.Get(HexagramRatioKey, Sequences.HexagramRatio);
+		HexagramText = Preferences.Get(HexagramTextKey, HexagramTextDefault);
+		HexagramLabel = Preferences.Get(HexagramLabelKey, HexagramLabelDefault);
+		HexagramSequence = Preferences.Get(HexagramSequenceKey, HexagramSequenceDefault);
+		HexagramRatio = Preferences.Get(HexagramRatioKey, HexagramRatioDefault);
 
-		TrigramText = Preferences.Get(TrigramTextKey, Sequences.TrigramText);
-		TrigramLabel = Preferences.Get(TrigramLabelKey, Sequences.TrigramLabel);
-		TrigramSequence = Preferences.Get(TrigramSequenceKey, Sequences.TrigramSequence);
-		TrigramRatio = Preferences.Get(TrigramRatioKey, Sequences.TrigramRatio);
+		TrigramText = Preferences.Get(TrigramTextKey, TrigramTextDefault);
+		TrigramLabel = Preferences.Get(TrigramLabelKey, TrigramLabelDefault);
+		TrigramSequence = Preferences.Get(TrigramSequenceKey, TrigramSequenceDefault);
+		TrigramRatio = Preferences.Get(TrigramRatioKey, TrigramRatioDefault);
 
-		LineText = Preferences.Get(LineTextKey, Sequences.LineText);
-		LineLabel = Preferences.Get(LineLabelKey, Sequences.LineLabel);
-		LineSequence = Preferences.Get(LineSequenceKey, Sequences.LineSequence);
-		LineRatio = Preferences.Get(LineRatioKey, Sequences.LineRatio);
+		LineText = Preferences.Get(LineTextKey, LineTextDefault);
+		LineLabel = Preferences.Get(LineLabelKey, LineLabelDefault);
+		LineSequence = Preferences.Get(LineSequenceKey, LineSequenceDefault);
+		LineRatio = Preferences.Get(LineRatioKey, LineRatioDefault);
 
-		EegDevice = Preferences.Get(EegDeviceKey, (int)eEegDevice.eMuse);
-		EegGoal = Preferences.Get(EegGoalKey, (int)eGoal.eYijingCast);
-		Ambience = Preferences.Get(AmbienceKey, (int)eAmbience.eLightRain);
-		Timer = Preferences.Get(TimerKey, (int)eTimer.eTwenty);
+		EegDevice = Preferences.Get(EegDeviceKey, EegDeviceDefault);
+		EegGoal = Preferences.Get(EegGoalKey, EegGoalDefault);
+		Ambience = Preferences.Get(AmbienceKey, AmbienceDefault);
+		Timer = Preferences.Get(TimerKey, TimerDefault);
 
-		ReplaySpeed = Preferences.Get(ReplaySpeedKey, (int)eReplaySpeed.eNormal);
-		ChartBands = Preferences.Get(ChartBandsKey, (int)eChartBands.eFront);
-		ChartTime = Preferences.Get(ChartTimeKey, (int)eChartTime.eTwoAndHalf);
+		ReplaySpeed = Preferences.Get(ReplaySpeedKey, ReplaySpeedDefault);
+		ChartBands = Preferences.Get(ChartBandsKey, ChartBandsDefault);
+		ChartTime = Preferences.Get(ChartTimeKey, ChartTimeDefault);
 
-		TriggerBand = Preferences.Get(TriggerBandKey, (int)eTriggerBand.eGamma);
-		TriggerChannel = Preferences.Get(TriggerChannelKey, (int)eTriggerChannel.eFrontLeft);
-		TriggerRange = Preferences.Get(TriggerRangeKey, (int)eTriggerRange.eTwoFour);
-		TriggerHunter = Preferences.Get(TriggerHunterKey, (int)eTriggerHunter.eFive);
-		TriggerSchedule = Preferences.Get(TriggerScheduleKey, (int)eTriggerSchedule.eSixty);
-		TriggerSounding = Preferences.Get(TriggerSoundingKey, true);
-		RawData = Preferences.Get(RawDataKey, false);
+		TriggerBand = Preferences.Get(TriggerBandKey, TriggerBandDefault);
+		TriggerChannel = Preferences.Get(TriggerChannelKey, TriggerChannelDefault);
+		TriggerRange = Preferences.Get(TriggerRangeKey, TriggerRangeDefault);
+		TriggerHunter = Preferences.Get(TriggerHunterKey, TriggerHunterDefault);
+		TriggerSchedule = Preferences.Get(TriggerScheduleKey, TriggerScheduleDefault);
+		TriggerSounding = Preferences.Get(TriggerSoundingKey, TriggerSoundingDefault);
+		RawData = Preferences.Get(RawDataKey, RawDataDefault);
 
-		AiChatService = Preferences.Get(AiChatServiceKey, (int)eAiService.eNone);
+		AiChatService = Preferences.Get(AiChatServiceKey, AiChatServiceDefault);
 
-		AiEegService = Preferences.Get(AiEegServiceKey, (int)eAiService.eNone);
-		AiEegMlModel = Preferences.Get(AiEegMlModelKey, (int)eAiEegMlModel.eNone);
+		AiEegService = Preferences.Get(AiEegServiceKey, AiEegServiceDefault);
+		AiEegMlModel = Preferences.Get(AiEegMlModelKey, AiEegMlModelDefault);
 	}
 
 	public static void Save()
@@ -155,6 +189,45 @@ public static class AppPreferences
 		Preferences.Set(AiChatServiceKey, AiChatService);
 		Preferences.Set(AiEegServiceKey, AiEegService);
 		Preferences.Set(AiEegMlModelKey, AiEegMlModel);
+	}
+
+	public static void Reset()
+	{
+		DiagramLsb = DiagramLsbDefault;
+		DiagramMode = DiagramModeDefault;
+		DiagramType = DiagramTypeDefault;
+		DiagramColor = DiagramColorDefault;
+		DiagramSpeed = DiagramSpeedDefault;
+		HexagramText = HexagramTextDefault;
+		HexagramLabel = HexagramLabelDefault;
+		HexagramSequence = HexagramSequenceDefault;
+		HexagramRatio = HexagramRatioDefault;
+		TrigramText = TrigramTextDefault;
+		TrigramLabel = TrigramLabelDefault;
+		TrigramSequence = TrigramSequenceDefault;
+		TrigramRatio = TrigramRatioDefault;
+		LineText = LineTextDefault;
+		LineLabel = LineLabelDefault;
+		LineSequence = LineSequenceDefault;
+		LineRatio = LineRatioDefault;
+		EegDevice = EegDeviceDefault;
+		EegGoal = EegGoalDefault;
+		Ambience = AmbienceDefault;
+		Timer = TimerDefault;
+		ReplaySpeed = ReplaySpeedDefault;
+		ChartBands = ChartBandsDefault;
+		ChartTime = ChartTimeDefault;
+		TriggerBand = TriggerBandDefault;
+		TriggerChannel = TriggerChannelDefault;
+		TriggerRange = TriggerRangeDefault;
+		TriggerHunter = TriggerHunterDefault;
+		TriggerSchedule = TriggerScheduleDefault;
+		TriggerSounding = TriggerSoundingDefault;
+		RawData = RawDataDefault;
+		AiChatService = AiChatServiceDefault;
+		AiEegService = AiEegServiceDefault;
+		AiEegMlModel = AiEegMlModelDefault;
+		Save();
 	}
 
 	public static int DiagramLsb;

--- a/Yijing.maui/Services/AppPreferences.cs
+++ b/Yijing.maui/Services/AppPreferences.cs
@@ -36,57 +36,125 @@ public enum ePages { eNone, eSession, eDiagram, eEeg, eMeditation, eSettings, eA
 
 public static class AppPreferences
 {
+	public const string DiagramLsbKey = "DiagramLsb";
+	public const string DiagramModeKey = "DiagramMode";
+	public const string DiagramTypeKey = "DiagramType";
+	public const string DiagramColorKey = "DiagramColor";
+	public const string DiagramSpeedKey = "DiagramSpeed";
+	public const string HexagramTextKey = "HexagramText";
+	public const string HexagramLabelKey = "HexagramLabel";
+	public const string HexagramSequenceKey = "HexagramSequence";
+	public const string HexagramRatioKey = "HexagramRatio";
+	public const string TrigramTextKey = "TrigramText";
+	public const string TrigramLabelKey = "TrigramLabel";
+	public const string TrigramSequenceKey = "TrigramSequence";
+	public const string TrigramRatioKey = "TrigramRatio";
+	public const string LineTextKey = "LineText";
+	public const string LineLabelKey = "LineLabel";
+	public const string LineSequenceKey = "LineSequence";
+	public const string LineRatioKey = "LineRatio";
+	public const string EegDeviceKey = "EegDevice";
+	public const string EegGoalKey = "EegGoal";
+	public const string AmbienceKey = "Ambience";
+	public const string TimerKey = "Timer";
+	public const string ReplaySpeedKey = "ReplaySpeed";
+	public const string ChartBandsKey = "ChartBands";
+	public const string ChartTimeKey = "ChartTime";
+	public const string TriggerBandKey = "TriggerBand";
+	public const string TriggerChannelKey = "TriggerChannel";
+	public const string TriggerRangeKey = "TriggerRange";
+	public const string TriggerHunterKey = "TriggerHunter";
+	public const string TriggerScheduleKey = "TriggerSchedule";
+	public const string TriggerSoundingKey = "TriggerSounding";
+	public const string RawDataKey = "RawData";
+	public const string AiChatServiceKey = "AiChatService";
+	public const string AiEegServiceKey = "AiEegService";
+	public const string AiEegMlModelKey = "AiEegMlModel";
+
 	public static void Load()
 	{
 
-		DiagramLsb = Preferences.Get("DiagramLsb", Sequences.DiagramLsb);
+		DiagramLsb = Preferences.Get(DiagramLsbKey, Sequences.DiagramLsb);
 
-		DiagramMode = Preferences.Get("DiagramMode", (int)eDiagramMode.eExplore);
-		DiagramType = Preferences.Get("DiagramType", (int)eDiagramType.eHexagram);
-		DiagramColor = Preferences.Get("DiagramColor", (int)eDiagramColor.eTrigram);
-		DiagramSpeed = Preferences.Get("DiagramSpeed", (int)eDiagramSpeed.eMedium);
+		DiagramMode = Preferences.Get(DiagramModeKey, (int)eDiagramMode.eExplore);
+		DiagramType = Preferences.Get(DiagramTypeKey, (int)eDiagramType.eHexagram);
+		DiagramColor = Preferences.Get(DiagramColorKey, (int)eDiagramColor.eTrigram);
+		DiagramSpeed = Preferences.Get(DiagramSpeedKey, (int)eDiagramSpeed.eMedium);
 
-		HexagramText = Preferences.Get("HexagramText", Sequences.HexagramText);
-		HexagramLabel = Preferences.Get("HexagramLabel", Sequences.HexagramLabel);
-		HexagramSequence = Preferences.Get("HexagramSequence", Sequences.HexagramSequence);
-		HexagramRatio = Preferences.Get("HexagramRatio", Sequences.HexagramRatio);
+		HexagramText = Preferences.Get(HexagramTextKey, Sequences.HexagramText);
+		HexagramLabel = Preferences.Get(HexagramLabelKey, Sequences.HexagramLabel);
+		HexagramSequence = Preferences.Get(HexagramSequenceKey, Sequences.HexagramSequence);
+		HexagramRatio = Preferences.Get(HexagramRatioKey, Sequences.HexagramRatio);
 
-		TrigramText = Preferences.Get("TrigramText", Sequences.TrigramText);
-		TrigramLabel = Preferences.Get("TrigramLabel", Sequences.TrigramLabel);
-		TrigramSequence = Preferences.Get("TrigramSequence", Sequences.TrigramSequence);
-		TrigramRatio = Preferences.Get("TrigramRatio", Sequences.TrigramRatio);
+		TrigramText = Preferences.Get(TrigramTextKey, Sequences.TrigramText);
+		TrigramLabel = Preferences.Get(TrigramLabelKey, Sequences.TrigramLabel);
+		TrigramSequence = Preferences.Get(TrigramSequenceKey, Sequences.TrigramSequence);
+		TrigramRatio = Preferences.Get(TrigramRatioKey, Sequences.TrigramRatio);
 
-		LineText = Preferences.Get("LineText", Sequences.LineText);
-		LineLabel = Preferences.Get("LineLabel", Sequences.LineLabel);
-		LineSequence = Preferences.Get("LineSequence", Sequences.LineSequence);
-		LineRatio = Preferences.Get("LineRatio", Sequences.LineRatio);
+		LineText = Preferences.Get(LineTextKey, Sequences.LineText);
+		LineLabel = Preferences.Get(LineLabelKey, Sequences.LineLabel);
+		LineSequence = Preferences.Get(LineSequenceKey, Sequences.LineSequence);
+		LineRatio = Preferences.Get(LineRatioKey, Sequences.LineRatio);
 
-		EegDevice = Preferences.Get("EegDevice", (int)eEegDevice.eMuse);
-		EegGoal = Preferences.Get("EegGoal", (int)eGoal.eYijingCast);
-		Ambience = Preferences.Get("Ambience", (int)eAmbience.eLightRain);
-		Timer = Preferences.Get("Timer", (int)eTimer.eTwenty);
+		EegDevice = Preferences.Get(EegDeviceKey, (int)eEegDevice.eMuse);
+		EegGoal = Preferences.Get(EegGoalKey, (int)eGoal.eYijingCast);
+		Ambience = Preferences.Get(AmbienceKey, (int)eAmbience.eLightRain);
+		Timer = Preferences.Get(TimerKey, (int)eTimer.eTwenty);
 
-		ReplaySpeed = Preferences.Get("ReplaySpeed", (int)eReplaySpeed.eNormal);
-		ChartBands = Preferences.Get("ChartBands", (int)eChartBands.eFront);
-		ChartTime = Preferences.Get("ChartTime", (int)eChartTime.eTwoAndHalf);
+		ReplaySpeed = Preferences.Get(ReplaySpeedKey, (int)eReplaySpeed.eNormal);
+		ChartBands = Preferences.Get(ChartBandsKey, (int)eChartBands.eFront);
+		ChartTime = Preferences.Get(ChartTimeKey, (int)eChartTime.eTwoAndHalf);
 
-		TriggerBand = Preferences.Get("TriggerBand", (int)eTriggerBand.eGamma);
-		TriggerChannel = Preferences.Get("TriggerChannel", (int)eTriggerChannel.eFrontLeft);
-		TriggerRange = Preferences.Get("TriggerRange", (int)eTriggerRange.eTwoFour);
-		TriggerHunter = Preferences.Get("TriggerHunter", (int)eTriggerHunter.eFive);
-		TriggerSchedule = Preferences.Get("TriggerSchedule", (int)eTriggerSchedule.eSixty);
-		TriggerSounding = Preferences.Get("TriggerSounding", true);
-		RawData = Preferences.Get("RawData", false);
+		TriggerBand = Preferences.Get(TriggerBandKey, (int)eTriggerBand.eGamma);
+		TriggerChannel = Preferences.Get(TriggerChannelKey, (int)eTriggerChannel.eFrontLeft);
+		TriggerRange = Preferences.Get(TriggerRangeKey, (int)eTriggerRange.eTwoFour);
+		TriggerHunter = Preferences.Get(TriggerHunterKey, (int)eTriggerHunter.eFive);
+		TriggerSchedule = Preferences.Get(TriggerScheduleKey, (int)eTriggerSchedule.eSixty);
+		TriggerSounding = Preferences.Get(TriggerSoundingKey, true);
+		RawData = Preferences.Get(RawDataKey, false);
 
-		AiChatService = Preferences.Get("AiChatService", (int)eAiService.eNone);
+		AiChatService = Preferences.Get(AiChatServiceKey, (int)eAiService.eNone);
 
-		AiEegService = Preferences.Get("AiEegService", (int)eAiService.eNone);
-		AiEegMlModel = Preferences.Get("AiEegMlModel", (int)eAiEegMlModel.eNone);
+		AiEegService = Preferences.Get(AiEegServiceKey, (int)eAiService.eNone);
+		AiEegMlModel = Preferences.Get(AiEegMlModelKey, (int)eAiEegMlModel.eNone);
 	}
 
 	public static void Save()
 	{
-		Preferences.Set("DiagramLsb", DiagramLsb);
+		Preferences.Set(DiagramLsbKey, DiagramLsb);
+		Preferences.Set(DiagramModeKey, DiagramMode);
+		Preferences.Set(DiagramTypeKey, DiagramType);
+		Preferences.Set(DiagramColorKey, DiagramColor);
+		Preferences.Set(DiagramSpeedKey, DiagramSpeed);
+		Preferences.Set(HexagramTextKey, HexagramText);
+		Preferences.Set(HexagramLabelKey, HexagramLabel);
+		Preferences.Set(HexagramSequenceKey, HexagramSequence);
+		Preferences.Set(HexagramRatioKey, HexagramRatio);
+		Preferences.Set(TrigramTextKey, TrigramText);
+		Preferences.Set(TrigramLabelKey, TrigramLabel);
+		Preferences.Set(TrigramSequenceKey, TrigramSequence);
+		Preferences.Set(TrigramRatioKey, TrigramRatio);
+		Preferences.Set(LineTextKey, LineText);
+		Preferences.Set(LineLabelKey, LineLabel);
+		Preferences.Set(LineSequenceKey, LineSequence);
+		Preferences.Set(LineRatioKey, LineRatio);
+		Preferences.Set(EegDeviceKey, EegDevice);
+		Preferences.Set(EegGoalKey, EegGoal);
+		Preferences.Set(AmbienceKey, Ambience);
+		Preferences.Set(TimerKey, Timer);
+		Preferences.Set(ReplaySpeedKey, ReplaySpeed);
+		Preferences.Set(ChartBandsKey, ChartBands);
+		Preferences.Set(ChartTimeKey, ChartTime);
+		Preferences.Set(TriggerBandKey, TriggerBand);
+		Preferences.Set(TriggerChannelKey, TriggerChannel);
+		Preferences.Set(TriggerRangeKey, TriggerRange);
+		Preferences.Set(TriggerHunterKey, TriggerHunter);
+		Preferences.Set(TriggerScheduleKey, TriggerSchedule);
+		Preferences.Set(TriggerSoundingKey, TriggerSounding);
+		Preferences.Set(RawDataKey, RawData);
+		Preferences.Set(AiChatServiceKey, AiChatService);
+		Preferences.Set(AiEegServiceKey, AiEegService);
+		Preferences.Set(AiEegMlModelKey, AiEegMlModel);
 	}
 
 	public static int DiagramLsb;


### PR DESCRIPTION
### Motivation
- Remove scattered magic strings for preference keys and centralize them as constants to prevent typos and make maintenance easier.
- Ensure all user preferences are saved when the application exits so settings persist between runs.

### Description
- Added `*Key` constant strings to `AppPreferences` for every preference key previously used as a literal string.
- Updated `AppPreferences.Load()` to use the new key constants and completed `AppPreferences.Save()` to write all preference values via `Preferences.Set`.
- Hooked the main window `Destroying` event in `App.xaml.cs` to call `AppPreferences.Save()` so preferences are persisted on app exit and added the required `using Yijing.Services;` import.

### Testing
- No automated tests were executed for this change.
- No automated test failures reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697604d1d9f8832b9ae424ce82a57fc4)