### PR TITLE
Refactor AiPreferences to use MAUI Preferences

### DIFF
--- a/Yijing.maui/App.xaml.cs
+++ b/Yijing.maui/App.xaml.cs
@@ -31,7 +31,7 @@ public partial class App : Application
 	{
 		//Window window = base.CreateWindow(activationState);
 		Window window = new Window(new AppShell());
-		window.Destroying += (s, e) => AppPreferences.Save();
+		window.Destroying += (s, e) => { AppPreferences.Save(); AiPreferences.Save(); };
 		window.Created += (s, e) =>
 		{
 			//window.X = 100;

--- a/Yijing.maui/Services/AppPreferences.cs
+++ b/Yijing.maui/Services/AppPreferences.cs
@@ -294,7 +294,7 @@ public static class AiPreferences
 	public const string GithubKeyDefault = "";
 	public const string OllamaModelDefault = "gpt-oss:20b";
 	public const string OllamaEndPointDefault = "http://localhost:11434/v1";
-	public const string OllamaKeyDefault = "";
+	public const string OllamaKeyDefault = "ollama";
 
 	public static void Load()
 	{
@@ -413,3 +413,112 @@ public static class AiPreferences
 
 }
 
+
+
+
+/*
+	public static void Load()
+	{
+
+		var configuration = new ConfigurationBuilder()
+			.SetBasePath(AppSettings.DocumentHome())
+			.AddJsonFile("appsettings.json", optional: true)
+			.Build();
+
+		if (float.TryParse(configuration["AI:Temperature"], out float temp1))
+			AiTemperature = temp1;
+		else
+			AiTemperature = 1.0f;
+		if (float.TryParse(configuration["AI:TopP"], out float temp2))
+			AiTopP = temp2;
+		else
+			AiTopP = 1.0f;
+		if (int.TryParse(configuration["AI:MaxTokens"], out int temp3))
+			AiMaxTokens = temp3;
+		else
+			AiMaxTokens = 10240;
+
+		AiServices = new Dictionary<string, AiServiceInfo>(StringComparer.OrdinalIgnoreCase)
+		{
+			[AiServiceNames[(int)eAiService.eOpenAi - 1]] = new AiServiceInfo(
+				ModelId: configuration["AI:Providers:OpenAI:Model"] ?? "",
+				EndPoint: configuration["AI:Providers:OpenAI:EndPoint"] ?? "",
+				Key: configuration["AI:Providers:OpenAI:Key"] ?? ""),
+			[AiServiceNames[(int)eAiService.eDeepseek - 1]] = new AiServiceInfo(
+				ModelId: configuration["AI:Providers:Deepseek:Model"] ?? "",
+				EndPoint: configuration["AI:Providers:Deepseek:EndPoint"] ?? "",
+				Key: configuration["AI:Providers:Deepseek:Key"] ?? ""),
+			[AiServiceNames[(int)eAiService.eGithub - 1]] = new AiServiceInfo(
+				ModelId: configuration["AI:Providers:Github:Model"] ?? "",
+				EndPoint: configuration["AI:Providers:Github:EndPoint"] ?? "",
+				Key: configuration["AI:Providers:Github:Key"] ?? ""),
+			[AiServiceNames[(int)eAiService.eOllama - 1]] = new AiServiceInfo(
+				ModelId: configuration["AI:Providers:Ollama:Model"] ?? "",
+				EndPoint: configuration["AI:Providers:Ollama:EndPoint"] ?? "",
+				Key: configuration["AI:Providers:Ollama:Key"] ?? "")
+		};
+	}
+
+private static void SaveNewDefaults()
+{
+	try
+	{
+		string settingsPath = Path.Combine(AppSettings.DocumentHome(), "appsettings.json");
+		JsonObject rootObject = LoadConfigurationObject(settingsPath);
+		JsonObject aiObject = rootObject["AI"] as JsonObject ?? new JsonObject();
+		rootObject["AI"] = aiObject;
+		JsonObject providersObject = aiObject["Providers"] as JsonObject ?? new JsonObject();
+		aiObject["Providers"] = providersObject;
+
+		bool save = false;
+
+		JsonObject openAIObject = providersObject["OpenAI"] as JsonObject ?? new JsonObject();
+		providersObject["OpenAI"] = openAIObject;
+		string? openAiEndpoint = (string?)openAIObject["EndPoint"];
+		if (string.IsNullOrWhiteSpace(openAiEndpoint))
+		{
+			openAiEndpoint = DefaultOpenAiEndpoint;
+			openAIObject["EndPoint"] = openAiEndpoint;
+			save = true;
+		}
+		UpdateServiceInfo(AiServiceName[(int)eAiService.eOpenAi - 1], endPoint: openAiEndpoint ?? "");
+
+		JsonObject ollamaObject = providersObject["Ollama"] as JsonObject ?? new JsonObject();
+		providersObject["Ollama"] = ollamaObject;
+		string? ollamaKey = (string?)ollamaObject["Key"];
+		if (string.IsNullOrWhiteSpace(ollamaKey))
+		{
+			ollamaKey = DefaultOllamaKey;
+			ollamaObject["Key"] = ollamaKey;
+			save = true;
+		}
+		UpdateServiceInfo(AiServiceName[(int)eAiService.eOllama - 1], key: ollamaKey ?? "");
+
+		var jsonOptions = new JsonSerializerOptions { WriteIndented = true };
+		if (save)
+			File.WriteAllText(settingsPath, rootObject.ToJsonString(jsonOptions));
+	}
+	catch (Exception) { }
+}
+
+private static JsonObject LoadConfigurationObject(string settingsPath)
+{
+	if (File.Exists(settingsPath))
+	{
+		string json = File.ReadAllText(settingsPath);
+		if (!string.IsNullOrWhiteSpace(json))
+		{
+			try
+			{
+				JsonNode? parsed = JsonNode.Parse(json);
+				if (parsed is JsonObject jsonObject)
+					return jsonObject;
+			}
+			catch (JsonException)
+			{
+			}
+		}
+	}
+	return new JsonObject();
+}
+*/


### PR DESCRIPTION
### Motivation

- Replace JSON-based AI configuration with MAUI `Preferences` to match `AppPreferences` usage and simplify cross-platform storage.
- Provide explicit `Load`, `Save`, and `Reset` methods for AI settings to allow runtime persistence and reset-to-default behavior.
- Use the existing `AiServiceNames` as dictionary keys and compose preference keys from the service name and field name (e.g. `OpenAI-ModelId`).

### Description

- Converted `AiPreferences` to read/write `AiTemperature`, `AiTopP`, `AiMaxTokens` and provider fields via MAUI `Preferences` with named keys and default constants in `Yijing.maui/Services/AppPreferences.cs`.
- Added `Load()`, `Save()`, and `Reset()` methods plus helpers `ServicePreferenceKey()` and `GetServiceDefaults()` to handle per-provider defaults and preference key generation.
- Populates `AiServices` from preferences on `Load()` and persists each provider's `ModelId`, `EndPoint`, and `Key` on `Save()`; `Reset()` restores the supplied defaults then saves them.
- Removed unused JSON/Configuration using directives and the old `ConfigurationBuilder`/appsettings.json parsing logic.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976ef883c88832bbb75abfe53f5d3d3)