### PR TITLE
Persist AI service names in preferences (comma-separated list)

### DIFF
--- a/Yijing.maui/Pages/SessionPage.xaml
+++ b/Yijing.maui/Pages/SessionPage.xaml
@@ -48,17 +48,10 @@
 						Text="Chat Service"
 						VerticalTextAlignment="Center" />
 
-					<Picker
-						x:Name="picAiChatService"
-						SelectedIndexChanged="picAiChatService_SelectedIndexChanged">
-						<Picker.Items>
-							<x:String>None</x:String>
-							<x:String>OpenAi</x:String>
-							<x:String>Deepseek</x:String>
-							<x:String>Github</x:String>
-							<x:String>Ollama</x:String>
-						</Picker.Items>
-					</Picker>
+				<Picker
+					x:Name="picAiChatService"
+					SelectedIndexChanged="picAiChatService_SelectedIndexChanged">
+				</Picker>
 
 					<CheckBox 
 						x:Name="chbIncludeCast"

--- a/Yijing.maui/Pages/SessionPage.xaml.cs
+++ b/Yijing.maui/Pages/SessionPage.xaml.cs
@@ -19,7 +19,9 @@ public partial class SessionPage : ContentPage
 			vslInput.BackgroundColor = Colors.Black;
 		}
 
-		picAiChatService.SelectedIndex = AppPreferences.AiChatService;
+		picAiChatService.ItemsSource = AiPreferences.ServicePickerNames();
+		AppPreferences.AiChatService = AiPreferences.NormalizeServiceName(AppPreferences.AiChatService);
+		picAiChatService.SelectedItem = AppPreferences.AiChatService;
 		chbIncludeCast.IsChecked = true;
 
 		horMenu.Create(ePages.eSession, StackOrientation.Horizontal);
@@ -61,9 +63,7 @@ public partial class SessionPage : ContentPage
 
 	private void picAiChatService_SelectedIndexChanged(object sender, EventArgs e)
 	{
-		AppPreferences.AiChatService = picAiChatService.SelectedIndex;
-		//btnAiOrNote.Text = AppPreferences.AiChatService == (int)eAiService.eNone ? "Add Note" : "Ask AI";
-		//btnAiOrNote.IsEnabled = AppPreferences.AiChatService != (int)eAiService.eNone;
+		AppPreferences.AiChatService = AiPreferences.NormalizeServiceName(picAiChatService.SelectedItem as string);
 	}
 
 	private void SessionView_ChatUpdated(object sender, string html)

--- a/Yijing.maui/Services/Ai.cs
+++ b/Yijing.maui/Services/Ai.cs
@@ -52,16 +52,19 @@ public class Ai
 		_chatHistory.AddAssistantMessage(message);
 	}
 
-	public async Task ChatAsync(int aiService, string prompt, bool functions)
+	public async Task ChatAsync(string aiService, string prompt, bool functions)
 	{
 		try
 		{
+			if (AiPreferences.IsNoneService(aiService))
+				return;
+
 			var builder = Kernel.CreateBuilder();
-			var serviceInfo = AiPreferences.AiService((eAiService)aiService);
+			var serviceInfo = AiPreferences.AiService(aiService);
 			var http = new HttpClient
 			{
 				Timeout = TimeSpan.FromMinutes(
-				aiService == (int)eAiService.eOllama ? 10 : 2)
+				AiPreferences.IsOllamaService(aiService) ? 10 : 2)
 			};
 
 			builder.AddOpenAIChatCompletion(serviceInfo.ModelId,

--- a/Yijing.maui/Services/AppPreferences.cs
+++ b/Yijing.maui/Services/AppPreferences.cs
@@ -275,10 +275,12 @@ public static class AppPreferences
 
 public static class AiPreferences
 {
+	public const string AiServiceNamesKey = "AI-ServiceNames";
 	public const string AiTemperatureKey = "AI-Temperature";
 	public const string AiTopPKey = "AI-TopP";
 	public const string AiMaxTokensKey = "AI-MaxTokens";
 
+	public const string AiServiceNamesDefault = "OpenAI,DeepSeek,Github,Ollama";
 	public const float AiTemperatureDefault = 1.0f;
 	public const float AiTopPDefault = 1.0f;
 	public const int AiMaxTokensDefault = 10240;
@@ -298,6 +300,10 @@ public static class AiPreferences
 
 	public static void Load()
 	{
+		AiServiceNames = ParseServiceNames(Preferences.Get(AiServiceNamesKey, AiServiceNamesDefault));
+		if (AiServiceNames.Length == 0)
+			AiServiceNames = ParseServiceNames(AiServiceNamesDefault);
+
 		AiTemperature = Preferences.Get(AiTemperatureKey, AiTemperatureDefault);
 		AiTopP = Preferences.Get(AiTopPKey, AiTopPDefault);
 		AiMaxTokens = Preferences.Get(AiMaxTokensKey, AiMaxTokensDefault);
@@ -315,6 +321,7 @@ public static class AiPreferences
 
 	public static void Save()
 	{
+		Preferences.Set(AiServiceNamesKey, string.Join(",", AiServiceNames));
 		Preferences.Set(AiTemperatureKey, AiTemperature);
 		Preferences.Set(AiTopPKey, AiTopP);
 		Preferences.Set(AiMaxTokensKey, AiMaxTokens);
@@ -332,6 +339,7 @@ public static class AiPreferences
 
 	public static void Reset()
 	{
+		AiServiceNames = ParseServiceNames(AiServiceNamesDefault);
 		AiTemperature = AiTemperatureDefault;
 		AiTopP = AiTopPDefault;
 		AiMaxTokens = AiMaxTokensDefault;
@@ -360,6 +368,17 @@ public static class AiPreferences
 	private static string ServicePreferenceKey(string serviceName, string fieldName)
 	{
 		return $"{serviceName}-{fieldName}";
+	}
+
+	private static string[] ParseServiceNames(string? value)
+	{
+		if (string.IsNullOrWhiteSpace(value))
+			return [];
+
+		return value
+			.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.ToArray();
 	}
 
 	private static AiServiceInfo GetServiceDefaults(string serviceName)
@@ -406,7 +425,7 @@ public static class AiPreferences
 	public static float AiTopP;
 	public static int AiMaxTokens;
 
-	public static string[] AiServiceNames = ["OpenAI", "DeepSeek", "Github", "Ollama"];
+	public static string[] AiServiceNames = [];
 	public record AiServiceInfo(string ModelId, string EndPoint, string Key);
 
 	public static Dictionary<string, AiServiceInfo> AiServices = new(StringComparer.OrdinalIgnoreCase);

--- a/Yijing.maui/Services/Eeg.cs
+++ b/Yijing.maui/Services/Eeg.cs
@@ -322,9 +322,9 @@ public class Eeg
 		if (!bSummary || (++m_nSummaryCount % 100 == 0))
 		{
 #if DEBUG
-			if (!bSummary && (m_nReplaySpeed == 1) && (AppPreferences.AiEegService != (int)eAiService.eNone))
+			if (!bSummary && (m_nReplaySpeed == 1) && !AiPreferences.IsNoneService(AppPreferences.AiEegService))
 #else
-			if (!bSummary && (m_bLive || (m_nReplaySpeed == 1)) && (AppPreferences.AiEegService != (int)eAiService.eNone))
+			if (!bSummary && (m_bLive || (m_nReplaySpeed == 1)) && !AiPreferences.IsNoneService(AppPreferences.AiEegService))
 #endif
 			{
 				DateTime Timestamp = DateTime.Now;
@@ -1097,4 +1097,3 @@ public class EmotivEeg : Eeg
 		"Gamma_TP9", "Gamma_AF7", "Gamma_AF8", "Gamma_TP10"
 	};
 */
-

--- a/Yijing.maui/Views/EegView.xaml
+++ b/Yijing.maui/Views/EegView.xaml
@@ -371,13 +371,6 @@
 					Grid.Column="1"
 					Grid.Row="14"
 					>
-					<Picker.Items>
-						<x:String>None</x:String>
-						<x:String>OpenAi</x:String>
-						<x:String>Deepseek</x:String>
-						<x:String>Github</x:String>
-						<x:String>Ollama</x:String>
-					</Picker.Items>
 				</Picker>
 
 				<Label 

--- a/Yijing.maui/Views/EegView.xaml.cs
+++ b/Yijing.maui/Views/EegView.xaml.cs
@@ -69,7 +69,9 @@ public partial class EegView : ContentView
 		picTriggerRange.SelectedIndex = AppPreferences.TriggerRange;
 		picTriggerHunter.SelectedIndex = AppPreferences.TriggerHunter;
 		picTriggerSchedule.SelectedIndex = AppPreferences.TriggerSchedule;
-		picAiAnalysis.SelectedIndex = AppPreferences.AiEegService;
+		picAiAnalysis.ItemsSource = AiPreferences.ServicePickerNames();
+		AppPreferences.AiEegService = AiPreferences.NormalizeServiceName(AppPreferences.AiEegService);
+		picAiAnalysis.SelectedItem = AppPreferences.AiEegService;
 		picAiModel.SelectedIndex = AppPreferences.AiEegMlModel;
 		chbTriggerSounding.IsChecked = AppPreferences.TriggerSounding;
 
@@ -208,7 +210,7 @@ public partial class EegView : ContentView
 			string s = (string)picSession.SelectedItem;
 			if (!string.IsNullOrEmpty(s))
 			{
-				if (picAiAnalysis.SelectedIndex != (int)eAiService.eNone)
+				if (!AiPreferences.IsNoneService(picAiAnalysis.SelectedItem as string))
 					UI.Call<EegPage>(p => p.SessionLog().Text = "");
 				_eeg.m_bCancelReplay = false;
 				void action() => _eeg.Replay(Path.Combine(AppSettings.EegDataHome(), s + (AppPreferences.EegDevice == (int)eEegDevice.eEmotiv ? "-Emotiv.csv" : "-Muse.csv")));
@@ -336,8 +338,8 @@ public partial class EegView : ContentView
 
 	private void picAiAnalysis_SelectedIndexChanged(object sender, EventArgs e)
 	{
-		AppPreferences.AiEegService = picAiAnalysis.SelectedIndex;
-		if (AppPreferences.AiEegService == (int)eAiService.eNone)
+		AppPreferences.AiEegService = AiPreferences.NormalizeServiceName(picAiAnalysis.SelectedItem as string);
+		if (AiPreferences.IsNoneService(AppPreferences.AiEegService))
 			UI.Call<EegPage>(p => p.ShowSessionLog(false));
 		else
 			UI.Call<EegPage>(p => p.ShowSessionLog(true));

--- a/Yijing.maui/Views/SessionView.xaml.cs
+++ b/Yijing.maui/Views/SessionView.xaml.cs
@@ -510,7 +510,7 @@ public partial class SessionView : ContentView
 			return;
 		}
 
-		if (AppPreferences.AiChatService == (int)eAiService.eNone)
+		if (AiPreferences.IsNoneService(AppPreferences.AiChatService))
 			_sessionNotes.Add(prompt);
 		else
 		{


### PR DESCRIPTION
### Motivation
- Replace the hard-coded `AiServiceNames` array with a user-editable, persisted preference so provider names can be customized at runtime.

### Description
- Add `AiServiceNamesKey` and `AiServiceNamesDefault` and persist provider names as a comma-separated preference in `Yijing.maui/Services/AppPreferences.cs`.
- Implement `ParseServiceNames` to split, trim, remove empties, and deduplicate names when loading the preference.
- Load now reads and parses the stored preference (falling back to defaults if empty), `Save` writes the joined CSV string, and `Reset` restores parsed defaults before rebuilding `AiServices`.
- Initialize `AiServiceNames` as an empty array and populate it during `Load` rather than using a hard-coded literal.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976fc55a328832b85e7410669ea3408)