### PR TITLE
Add Settings page and SettingsView for AI preferences

### DIFF
--- a/Yijing.maui/AppShell.xaml
+++ b/Yijing.maui/AppShell.xaml
@@ -48,4 +48,14 @@
 			Route="MeditationRoot" />
 	</FlyoutItem>
 
+	<FlyoutItem Route="Settings">
+		<ShellContent
+			x:Name="pagSettings"
+			Shell.NavBarIsVisible="false"
+			Title="Settings"
+			Icon="iconlistdetail.png"
+			ContentTemplate="{DataTemplate pages:SettingsPage}"
+			Route="SettingsRoot" />
+	</FlyoutItem>
+
 </Shell>

--- a/Yijing.maui/Pages/SettingsPage.xaml
+++ b/Yijing.maui/Pages/SettingsPage.xaml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+
+	xmlns:views="clr-namespace:Yijing.Views"
+	x:Class="Yijing.Pages.SettingsPage"
+	Loaded="Page_Loaded">
+
+	<toolkit:DockLayout
+		ShouldExpandLastChild="true">
+
+		<views:MenuView
+			x:Name="horMenu"
+			toolkit:DockLayout.DockPosition="Bottom" />
+
+		<views:MenuView
+			x:Name="verMenu"
+			toolkit:DockLayout.DockPosition="{x:Static views:MenuView.VerticalDockPosition}" />
+
+		<views:SettingsView x:Name="settingsView" />
+	</toolkit:DockLayout>
+</ContentPage>

--- a/Yijing.maui/Pages/SettingsPage.xaml.cs
+++ b/Yijing.maui/Pages/SettingsPage.xaml.cs
@@ -1,0 +1,44 @@
+using Yijing.Services;
+using Yijing.Views;
+
+namespace Yijing.Pages;
+
+public partial class SettingsPage : ContentPage
+{
+	public SettingsPage()
+	{
+		Behaviors.Add(new RegisterInViewDirectoryBehavior());
+		InitializeComponent();
+
+		horMenu.Create(ePages.eSettings, StackOrientation.Horizontal);
+		verMenu.Create(ePages.eSettings, StackOrientation.Vertical);
+	}
+
+	private void Page_Loaded(object sender, EventArgs e)
+	{
+	}
+
+	protected override void OnSizeAllocated(double width, double height)
+	{
+		if ((width == -1) || (height == -1))
+			return;
+
+#if ANDROID || IOS
+		if (width > height)
+		{
+			horMenu.IsVisible = false;
+			verMenu.IsVisible = true;
+		}
+		else
+		{
+			horMenu.IsVisible = true;
+			verMenu.IsVisible = false;
+		}
+#else
+		horMenu.IsVisible = false;
+		verMenu.IsVisible = true;
+#endif
+
+		base.OnSizeAllocated(width, height);
+	}
+}

--- a/Yijing.maui/Pages/SettingsPage.xaml.cs
+++ b/Yijing.maui/Pages/SettingsPage.xaml.cs
@@ -28,16 +28,20 @@ public partial class SettingsPage : ContentPage
 		{
 			horMenu.IsVisible = false;
 			verMenu.IsVisible = true;
+			settingsView.ButtonPadding(new Thickness(0, 5));
 		}
 		else
 		{
 			horMenu.IsVisible = true;
 			verMenu.IsVisible = false;
+			settingsView.ButtonPadding(new Thickness(5));
 		}
 #else
 		horMenu.IsVisible = false;
 		verMenu.IsVisible = true;
+		settingsView.ButtonPadding(new Thickness(0, 5));
 #endif
+		settingsView.UpdateLayout(width, height);
 
 		base.OnSizeAllocated(width, height);
 	}

--- a/Yijing.maui/Pages/SettingsPage.xaml.cs
+++ b/Yijing.maui/Pages/SettingsPage.xaml.cs
@@ -28,18 +28,18 @@ public partial class SettingsPage : ContentPage
 		{
 			horMenu.IsVisible = false;
 			verMenu.IsVisible = true;
-			settingsView.ButtonPadding(new Thickness(0, 5));
+			settingsView.ButtonPadding(new Thickness(0, 8));
 		}
 		else
 		{
 			horMenu.IsVisible = true;
 			verMenu.IsVisible = false;
-			settingsView.ButtonPadding(new Thickness(5));
+			settingsView.ButtonPadding(new Thickness(8));
 		}
 #else
 		horMenu.IsVisible = false;
 		verMenu.IsVisible = true;
-		settingsView.ButtonPadding(new Thickness(0, 5));
+		settingsView.ButtonPadding(new Thickness(0, 8));
 #endif
 		settingsView.UpdateLayout(width, height);
 

--- a/Yijing.maui/Views/MenuView..cs
+++ b/Yijing.maui/Views/MenuView..cs
@@ -15,6 +15,7 @@ public partial class MenuView : ContentView
 	private ButtonEx _btnDiagram;
 	private ButtonEx _btnEeg;
 	private ButtonEx _btnMeditation;
+	private ButtonEx _btnSettings;
 
 
 #if WINDOWS || MACCATALYST
@@ -80,6 +81,10 @@ public partial class MenuView : ContentView
 		{
 			Icon = FluentIcons.MeditationPage,
 		};
+		_btnSettings = new ButtonEx()
+		{
+			Icon = FluentIcons.Setting,
+		};
 
 		if (orientation == StackOrientation.Vertical)
 #if WINDOWS || MACCATALYST
@@ -96,11 +101,13 @@ public partial class MenuView : ContentView
 		_slMenu.Children.Add(_btnDiagram);
 		_slMenu.Children.Add(_btnEeg);
 		_slMenu.Children.Add(_btnMeditation);
+		_slMenu.Children.Add(_btnSettings);
 
 		_btnSession.Clicked += btnSession_Clicked;
 		_btnDiagram.Clicked += btnDiagram_Clicked;
 		_btnEeg.Clicked += btnEeg_Clicked;
 		_btnMeditation.Clicked += btnMeditation_Clicked;
+		_btnSettings.Clicked += btnSettings_Clicked;
 
 		Content = border;
 	}
@@ -128,6 +135,12 @@ public partial class MenuView : ContentView
 	{
 		if (_ePage != ePages.eMeditation)
 			await Shell.Current.GoToAsync("//Meditation/MeditationRoot", true);
+	}
+
+	private async void btnSettings_Clicked(object sender, EventArgs e)
+	{
+		if (_ePage != ePages.eSettings)
+			await Shell.Current.GoToAsync("//Settings/SettingsRoot", true);
 	}
 
 	public static readonly BindableProperty CardColorProperty = BindableProperty.Create(nameof(CardColor),

--- a/Yijing.maui/Views/SettingsView.xaml
+++ b/Yijing.maui/Views/SettingsView.xaml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<ContentView
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:views="clr-namespace:Yijing.Views"
+	xmlns:controls="clr-namespace:Yijing.Controls"
+	x:Class="Yijing.Views.SettingsView"
+	x:Name="settingsView">
+
+	<Border>
+		<Grid RowDefinitions="Auto,*" ColumnDefinitions="260,*">
+			<HorizontalStackLayout
+				x:Name="hslButtons"
+				Grid.Row="0"
+				Grid.ColumnSpan="2"
+				Spacing="6">
+				<controls:ButtonEx
+					x:Name="btnSave"
+					Icon="{x:Static controls:FluentIcons.Save}"
+					Clicked="OnSaveClicked" />
+				<controls:ButtonEx
+					x:Name="btnReset"
+					Icon="{x:Static controls:FluentIcons.Restore}"
+					Clicked="OnResetClicked" />
+			</HorizontalStackLayout>
+
+			<Border
+				Grid.Row="1"
+				Grid.Column="0"
+				Margin="0,6,6,0">
+				<CollectionView
+					x:Name="propertyTree"
+					ItemsSource="{Binding PropertyNodes}"
+					SelectionMode="Single"
+					SelectionChanged="OnPropertySelectionChanged">
+					<CollectionView.ItemsLayout>
+						<LinearItemsLayout Orientation="Vertical" />
+					</CollectionView.ItemsLayout>
+					<CollectionView.ItemTemplate>
+						<DataTemplate x:DataType="views:SettingsNode">
+							<Grid Padding="{Binding Indent}">
+								<Label
+									Text="{Binding Title}"
+									FontAttributes="Bold" />
+							</Grid>
+						</DataTemplate>
+					</CollectionView.ItemTemplate>
+				</CollectionView>
+			</Border>
+
+			<ScrollView Grid.Row="1" Grid.Column="1">
+				<VerticalStackLayout Spacing="12">
+					<Label
+						Text="{Binding SelectedNodeTitle}"
+						FontSize="28" />
+					<BoxView HeightRequest="1" BackgroundColor="{AppThemeBinding Light=Black, Dark=White}" />
+					<Label Text="{Binding SelectedNodeDescription}" />
+
+					<VerticalStackLayout
+						IsVisible="{Binding IsAiPreferencesSelected}"
+						Spacing="12">
+						<Label
+							Text="AI Generation Settings"
+							FontSize="20"
+							FontAttributes="Bold" />
+						<Grid ColumnDefinitions="180,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8">
+							<Label
+								Text="Temperature"
+								Grid.Row="0"
+								Grid.Column="0"
+								VerticalTextAlignment="Center" />
+							<Entry
+								Grid.Row="0"
+								Grid.Column="1"
+								Text="{Binding AiTemperatureText}"
+								Placeholder="1.0" />
+
+							<Label
+								Text="Top P"
+								Grid.Row="1"
+								Grid.Column="0"
+								VerticalTextAlignment="Center" />
+							<Entry
+								Grid.Row="1"
+								Grid.Column="1"
+								Text="{Binding AiTopPText}"
+								Placeholder="1.0" />
+
+							<Label
+								Text="Max Tokens"
+								Grid.Row="2"
+								Grid.Column="0"
+								VerticalTextAlignment="Center" />
+							<Entry
+								Grid.Row="2"
+								Grid.Column="1"
+								Text="{Binding AiMaxTokensText}"
+								Placeholder="10240" />
+						</Grid>
+
+						<Label
+							Text="AI Services"
+							FontSize="20"
+							FontAttributes="Bold" />
+						<Label Text="Manage the available AI providers and their connection settings." />
+
+						<HorizontalStackLayout Spacing="8">
+							<Entry
+								Text="{Binding NewServiceName}"
+								Placeholder="New service name"
+								HorizontalOptions="FillAndExpand" />
+							<controls:ButtonEx
+								Icon="{x:Static controls:FluentIcons.Add}"
+								Clicked="OnAddServiceClicked" />
+						</HorizontalStackLayout>
+
+						<CollectionView ItemsSource="{Binding AiServices}">
+							<CollectionView.ItemsLayout>
+								<LinearItemsLayout Orientation="Vertical" />
+							</CollectionView.ItemsLayout>
+							<CollectionView.ItemTemplate>
+								<DataTemplate x:DataType="views:AiServiceEditor">
+									<Border Padding="8" Margin="0,6,0,0" BackgroundColor="{AppThemeBinding Light=White, Dark=Black}">
+										<VerticalStackLayout Spacing="6">
+											<Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+												<Entry
+													Text="{Binding Name}"
+													Placeholder="Service name" />
+												<controls:ButtonEx
+													Grid.Column="1"
+													Icon="{x:Static controls:FluentIcons.Delete}"
+													Clicked="OnDeleteServiceClicked"
+													CommandParameter="{Binding .}" />
+											</Grid>
+
+											<Label Text="Model Id" FontAttributes="Bold" />
+											<Entry
+												Text="{Binding ModelId}"
+												Placeholder="gpt-5.2" />
+
+											<Label Text="End Point" FontAttributes="Bold" />
+											<Entry
+												Text="{Binding EndPoint}"
+												Placeholder="https://api.openai.com/v1" />
+
+											<Label Text="Key" FontAttributes="Bold" />
+											<Entry
+												Text="{Binding Key}"
+												Placeholder="API key"
+												IsPassword="True" />
+										</VerticalStackLayout>
+									</Border>
+								</DataTemplate>
+							</CollectionView.ItemTemplate>
+						</CollectionView>
+					</VerticalStackLayout>
+				</VerticalStackLayout>
+			</ScrollView>
+		</Grid>
+	</Border>
+</ContentView>

--- a/Yijing.maui/Views/SettingsView.xaml
+++ b/Yijing.maui/Views/SettingsView.xaml
@@ -8,8 +8,12 @@
 	x:Class="Yijing.Views.SettingsView"
 	x:Name="settingsView">
 
-	<Border>
-		<Grid RowDefinitions="Auto,*" ColumnDefinitions="260,*">
+	<Border BackgroundColor="{AppThemeBinding Light=White, Dark=Black}">
+		<Grid RowDefinitions="Auto,*">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition x:Name="colTree" Width="260" />
+				<ColumnDefinition Width="*" />
+			</Grid.ColumnDefinitions>
 			<HorizontalStackLayout
 				x:Name="hslButtons"
 				Grid.Row="0"
@@ -26,9 +30,11 @@
 			</HorizontalStackLayout>
 
 			<Border
+				x:Name="borTree"
 				Grid.Row="1"
 				Grid.Column="0"
-				Margin="0,6,6,0">
+				Margin="0,6,6,0"
+				BackgroundColor="{AppThemeBinding Light=White, Dark=Black}">
 				<CollectionView
 					x:Name="propertyTree"
 					ItemsSource="{Binding PropertyNodes}"
@@ -37,20 +43,39 @@
 					<CollectionView.ItemsLayout>
 						<LinearItemsLayout Orientation="Vertical" />
 					</CollectionView.ItemsLayout>
-					<CollectionView.ItemTemplate>
-						<DataTemplate x:DataType="views:SettingsNode">
-							<Grid Padding="{Binding Indent}">
-								<Label
-									Text="{Binding Title}"
-									FontAttributes="Bold" />
-							</Grid>
-						</DataTemplate>
-					</CollectionView.ItemTemplate>
-				</CollectionView>
+						<CollectionView.ItemTemplate>
+							<DataTemplate x:DataType="views:SettingsNode">
+								<Grid Padding="{Binding Indent}">
+									<VisualStateManager.VisualStateGroups>
+										<VisualStateGroup Name="CommonStates">
+											<VisualState Name="Normal" />
+											<VisualState Name="Selected">
+												<VisualState.Setters>
+													<Setter Property="BackgroundColor" Value="#D97706" />
+													<Setter TargetName="lblNodeTitle" Property="Label.TextColor" Value="White" />
+												</VisualState.Setters>
+											</VisualState>
+										</VisualStateGroup>
+									</VisualStateManager.VisualStateGroups>
+									<Label
+										x:Name="lblNodeTitle"
+										Text="{Binding Title}"
+										FontAttributes="Bold"
+										TextColor="{AppThemeBinding Light=Black, Dark=White}" />
+								</Grid>
+							</DataTemplate>
+						</CollectionView.ItemTemplate>
+					</CollectionView>
 			</Border>
 
-			<ScrollView Grid.Row="1" Grid.Column="1">
-				<VerticalStackLayout Spacing="12">
+			<Border
+				x:Name="borDetails"
+				Grid.Row="1"
+				Grid.Column="1"
+				Margin="0,6,0,0"
+				BackgroundColor="{AppThemeBinding Light=White, Dark=Black}">
+				<ScrollView>
+					<VerticalStackLayout Spacing="12">
 					<Label
 						Text="{Binding SelectedNodeTitle}"
 						FontSize="28" />
@@ -156,7 +181,8 @@
 						</CollectionView>
 					</VerticalStackLayout>
 				</VerticalStackLayout>
-			</ScrollView>
+				</ScrollView>
+			</Border>
 		</Grid>
 	</Border>
 </ContentView>

--- a/Yijing.maui/Views/SettingsView.xaml
+++ b/Yijing.maui/Views/SettingsView.xaml
@@ -9,15 +9,16 @@
 	x:Name="settingsView">
 
 	<Border BackgroundColor="{AppThemeBinding Light=White, Dark=Black}">
-		<Grid RowDefinitions="Auto,*">
+		<Grid RowDefinitions="Auto,*" RowSpacing="6">
 			<Grid.ColumnDefinitions>
 				<ColumnDefinition x:Name="colTree" Width="260" />
-				<ColumnDefinition Width="*" />
+				<ColumnDefinition x:Name="colDetails" Width="*" />
 			</Grid.ColumnDefinitions>
 			<HorizontalStackLayout
 				x:Name="hslButtons"
 				Grid.Row="0"
 				Grid.ColumnSpan="2"
+				Padding="6,6,6,4"
 				Spacing="6">
 				<controls:ButtonEx
 					x:Name="btnSave"
@@ -33,7 +34,7 @@
 				x:Name="borTree"
 				Grid.Row="1"
 				Grid.Column="0"
-				Margin="0,6,6,0"
+				Margin="0,0,6,0"
 				BackgroundColor="{AppThemeBinding Light=White, Dark=Black}">
 				<CollectionView
 					x:Name="propertyTree"
@@ -72,7 +73,7 @@
 				x:Name="borDetails"
 				Grid.Row="1"
 				Grid.Column="1"
-				Margin="0,6,0,0"
+				Margin="0"
 				BackgroundColor="{AppThemeBinding Light=White, Dark=Black}">
 				<ScrollView>
 					<VerticalStackLayout Spacing="12">

--- a/Yijing.maui/Views/SettingsView.xaml
+++ b/Yijing.maui/Views/SettingsView.xaml
@@ -10,10 +10,6 @@
 
 	<Border BackgroundColor="{AppThemeBinding Light=White, Dark=Black}">
 		<Grid RowDefinitions="Auto,*" RowSpacing="6">
-			<Grid.ColumnDefinitions>
-				<ColumnDefinition x:Name="colTree" Width="260" />
-				<ColumnDefinition x:Name="colDetails" Width="*" />
-			</Grid.ColumnDefinitions>
 			<HorizontalStackLayout
 				x:Name="hslButtons"
 				Grid.Row="0"
@@ -30,20 +26,22 @@
 					Clicked="OnResetClicked" />
 			</HorizontalStackLayout>
 
-			<Border
-				x:Name="borTree"
+			<HorizontalStackLayout
 				Grid.Row="1"
-				Grid.Column="0"
-				Margin="0,0,6,0"
-				BackgroundColor="{AppThemeBinding Light=White, Dark=Black}">
-				<CollectionView
-					x:Name="propertyTree"
-					ItemsSource="{Binding PropertyNodes}"
-					SelectionMode="Single"
-					SelectionChanged="OnPropertySelectionChanged">
-					<CollectionView.ItemsLayout>
-						<LinearItemsLayout Orientation="Vertical" />
-					</CollectionView.ItemsLayout>
+				Grid.ColumnSpan="2"
+				Spacing="6">
+				<Border
+					x:Name="borTree"
+					HorizontalOptions="Start"
+					BackgroundColor="{AppThemeBinding Light=White, Dark=Black}">
+					<CollectionView
+						x:Name="propertyTree"
+						ItemsSource="{Binding PropertyNodes}"
+						SelectionMode="Single"
+						SelectionChanged="OnPropertySelectionChanged">
+						<CollectionView.ItemsLayout>
+							<LinearItemsLayout Orientation="Vertical" />
+						</CollectionView.ItemsLayout>
 						<CollectionView.ItemTemplate>
 							<DataTemplate x:DataType="views:SettingsNode">
 								<Grid Padding="{Binding Indent}">
@@ -67,123 +65,122 @@
 							</DataTemplate>
 						</CollectionView.ItemTemplate>
 					</CollectionView>
-			</Border>
+				</Border>
 
-			<Border
-				x:Name="borDetails"
-				Grid.Row="1"
-				Grid.Column="1"
-				Margin="0"
-				BackgroundColor="{AppThemeBinding Light=White, Dark=Black}">
-				<ScrollView>
-					<VerticalStackLayout Spacing="12">
-					<Label
-						Text="{Binding SelectedNodeTitle}"
-						FontSize="28" />
-					<BoxView HeightRequest="1" BackgroundColor="{AppThemeBinding Light=Black, Dark=White}" />
-					<Label Text="{Binding SelectedNodeDescription}" />
-
-					<VerticalStackLayout
-						IsVisible="{Binding IsAiPreferencesSelected}"
-						Spacing="12">
-						<Label
-							Text="AI Generation Settings"
-							FontSize="20"
-							FontAttributes="Bold" />
-						<Grid ColumnDefinitions="180,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8">
+				<Border
+					x:Name="borDetails"
+					HorizontalOptions="FillAndExpand"
+					BackgroundColor="{AppThemeBinding Light=White, Dark=Black}">
+					<ScrollView>
+						<VerticalStackLayout Spacing="12">
 							<Label
-								Text="Temperature"
-								Grid.Row="0"
-								Grid.Column="0"
-								VerticalTextAlignment="Center" />
-							<Entry
-								Grid.Row="0"
-								Grid.Column="1"
-								Text="{Binding AiTemperatureText}"
-								Placeholder="1.0" />
+								Text="{Binding SelectedNodeTitle}"
+								FontSize="28" />
+							<BoxView HeightRequest="1" BackgroundColor="{AppThemeBinding Light=Black, Dark=White}" />
+							<Label Text="{Binding SelectedNodeDescription}" />
 
-							<Label
-								Text="Top P"
-								Grid.Row="1"
-								Grid.Column="0"
-								VerticalTextAlignment="Center" />
-							<Entry
-								Grid.Row="1"
-								Grid.Column="1"
-								Text="{Binding AiTopPText}"
-								Placeholder="1.0" />
+							<VerticalStackLayout
+								IsVisible="{Binding IsAiPreferencesSelected}"
+								Spacing="12">
+								<Label
+									Text="AI Generation Settings"
+									FontSize="20"
+									FontAttributes="Bold" />
+								<Grid ColumnDefinitions="180,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8">
+									<Label
+										Text="Temperature"
+										Grid.Row="0"
+										Grid.Column="0"
+										VerticalTextAlignment="Center" />
+									<Entry
+										Grid.Row="0"
+										Grid.Column="1"
+										Text="{Binding AiTemperatureText}"
+										Placeholder="1.0" />
 
-							<Label
-								Text="Max Tokens"
-								Grid.Row="2"
-								Grid.Column="0"
-								VerticalTextAlignment="Center" />
-							<Entry
-								Grid.Row="2"
-								Grid.Column="1"
-								Text="{Binding AiMaxTokensText}"
-								Placeholder="10240" />
-						</Grid>
+									<Label
+										Text="Top P"
+										Grid.Row="1"
+										Grid.Column="0"
+										VerticalTextAlignment="Center" />
+									<Entry
+										Grid.Row="1"
+										Grid.Column="1"
+										Text="{Binding AiTopPText}"
+										Placeholder="1.0" />
 
-						<Label
-							Text="AI Services"
-							FontSize="20"
-							FontAttributes="Bold" />
-						<Label Text="Manage the available AI providers and their connection settings." />
+									<Label
+										Text="Max Tokens"
+										Grid.Row="2"
+										Grid.Column="0"
+										VerticalTextAlignment="Center" />
+									<Entry
+										Grid.Row="2"
+										Grid.Column="1"
+										Text="{Binding AiMaxTokensText}"
+										Placeholder="10240" />
+								</Grid>
 
-						<HorizontalStackLayout Spacing="8">
-							<Entry
-								Text="{Binding NewServiceName}"
-								Placeholder="New service name"
-								HorizontalOptions="FillAndExpand" />
-							<controls:ButtonEx
-								Icon="{x:Static controls:FluentIcons.Add}"
-								Clicked="OnAddServiceClicked" />
-						</HorizontalStackLayout>
+								<Label
+									Text="AI Services"
+									FontSize="20"
+									FontAttributes="Bold" />
+								<Label Text="Manage the available AI providers and their connection settings." />
 
-						<CollectionView ItemsSource="{Binding AiServices}">
-							<CollectionView.ItemsLayout>
-								<LinearItemsLayout Orientation="Vertical" />
-							</CollectionView.ItemsLayout>
-							<CollectionView.ItemTemplate>
-								<DataTemplate x:DataType="views:AiServiceEditor">
-									<Border Padding="8" Margin="0,6,0,0" BackgroundColor="{AppThemeBinding Light=White, Dark=Black}">
-										<VerticalStackLayout Spacing="6">
-											<Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
-												<Entry
-													Text="{Binding Name}"
-													Placeholder="Service name" />
-												<controls:ButtonEx
-													Grid.Column="1"
-													Icon="{x:Static controls:FluentIcons.Delete}"
-													Clicked="OnDeleteServiceClicked"
-													CommandParameter="{Binding .}" />
-											</Grid>
+								<HorizontalStackLayout Spacing="8">
+									<Entry
+										Text="{Binding NewServiceName}"
+										Placeholder="New service name"
+										HorizontalOptions="FillAndExpand" />
+									<controls:ButtonEx
+										Icon="{x:Static controls:FluentIcons.Add}"
+										Clicked="OnAddServiceClicked" />
+								</HorizontalStackLayout>
 
-											<Label Text="Model Id" FontAttributes="Bold" />
-											<Entry
-												Text="{Binding ModelId}"
-												Placeholder="gpt-5.2" />
+								<CollectionView ItemsSource="{Binding AiServices}">
+									<CollectionView.ItemsLayout>
+										<LinearItemsLayout Orientation="Vertical" />
+									</CollectionView.ItemsLayout>
+									<CollectionView.ItemTemplate>
+										<DataTemplate x:DataType="views:AiServiceEditor">
+											<Border Padding="8" Margin="0,6,0,0" BackgroundColor="{AppThemeBinding Light=White, Dark=Black}">
+												<VerticalStackLayout Spacing="6">
+													<Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+														<Entry
+															Text="{Binding Name}"
+															Placeholder="Service name" />
+														<controls:ButtonEx
+															Grid.Column="1"
+															Icon="{x:Static controls:FluentIcons.Delete}"
+															Clicked="OnDeleteServiceClicked"
+															CommandParameter="{Binding .}" />
+													</Grid>
 
-											<Label Text="End Point" FontAttributes="Bold" />
-											<Entry
-												Text="{Binding EndPoint}"
-												Placeholder="https://api.openai.com/v1" />
+													<Label Text="Model Id" FontAttributes="Bold" />
+													<Entry
+														Text="{Binding ModelId}"
+														Placeholder="gpt-5.2" />
 
-											<Label Text="Key" FontAttributes="Bold" />
-											<Entry
-												Text="{Binding Key}"
-												Placeholder="API key"
-												IsPassword="True" />
-										</VerticalStackLayout>
-									</Border>
-								</DataTemplate>
-							</CollectionView.ItemTemplate>
-						</CollectionView>
-					</VerticalStackLayout>
-				</VerticalStackLayout>
-				</ScrollView>
-			</Border>
+													<Label Text="End Point" FontAttributes="Bold" />
+													<Entry
+														Text="{Binding EndPoint}"
+														Placeholder="https://api.openai.com/v1" />
+
+													<Label Text="Key" FontAttributes="Bold" />
+													<Entry
+														Text="{Binding Key}"
+														Placeholder="API key"
+														IsPassword="True" />
+												</VerticalStackLayout>
+											</Border>
+										</DataTemplate>
+									</CollectionView.ItemTemplate>
+								</CollectionView>
+							</VerticalStackLayout>
+						</VerticalStackLayout>
+					</ScrollView>
+				</Border>
+			</HorizontalStackLayout>
 		</Grid>
 	</Border>
 </ContentView>

--- a/Yijing.maui/Views/SettingsView.xaml.cs
+++ b/Yijing.maui/Views/SettingsView.xaml.cs
@@ -36,9 +36,8 @@ public partial class SettingsView : ContentView
 			return;
 
 		bool isLandscape = width > height;
-		double treeWidth = isLandscape ? 260 : 0;
-		colTree.Width = isLandscape ? new GridLength(treeWidth) : new GridLength(1, GridUnitType.Star);
-		colDetails.Width = isLandscape ? new GridLength(1, GridUnitType.Star) : new GridLength(0);
+		double treeWidth = isLandscape ? 260 : width;
+		borTree.WidthRequest = treeWidth;
 		borDetails.IsVisible = isLandscape;
 		borTree.Margin = isLandscape ? new Thickness(0, 0, 6, 0) : new Thickness(0);
 	}

--- a/Yijing.maui/Views/SettingsView.xaml.cs
+++ b/Yijing.maui/Views/SettingsView.xaml.cs
@@ -36,10 +36,11 @@ public partial class SettingsView : ContentView
 			return;
 
 		bool isLandscape = width > height;
-		double treeWidth = isLandscape ? 260 : 200;
-		colTree.Width = new GridLength(treeWidth);
-		borTree.Margin = isLandscape ? new Thickness(0, 6, 6, 0) : new Thickness(0, 6, 4, 0);
-		borDetails.Margin = isLandscape ? new Thickness(0, 6, 0, 0) : new Thickness(0, 6, 0, 0);
+		double treeWidth = isLandscape ? 260 : 0;
+		colTree.Width = isLandscape ? new GridLength(treeWidth) : new GridLength(1, GridUnitType.Star);
+		colDetails.Width = isLandscape ? new GridLength(1, GridUnitType.Star) : new GridLength(0);
+		borDetails.IsVisible = isLandscape;
+		borTree.Margin = isLandscape ? new Thickness(0, 0, 6, 0) : new Thickness(0);
 	}
 
 	public void ButtonPadding(Thickness thickness)

--- a/Yijing.maui/Views/SettingsView.xaml.cs
+++ b/Yijing.maui/Views/SettingsView.xaml.cs
@@ -30,6 +30,24 @@ public partial class SettingsView : ContentView
 		LoadAiPreferences();
 	}
 
+	public void UpdateLayout(double width, double height)
+	{
+		if ((width <= 0) || (height <= 0))
+			return;
+
+		bool isLandscape = width > height;
+		double treeWidth = isLandscape ? 260 : 200;
+		colTree.Width = new GridLength(treeWidth);
+		borTree.Margin = isLandscape ? new Thickness(0, 6, 6, 0) : new Thickness(0, 6, 4, 0);
+		borDetails.Margin = isLandscape ? new Thickness(0, 6, 0, 0) : new Thickness(0, 6, 0, 0);
+	}
+
+	public void ButtonPadding(Thickness thickness)
+	{
+		btnSave.Padding = thickness;
+		btnReset.Padding = thickness;
+	}
+
 	public SettingsNode? SelectedNode
 	{
 		get => _selectedNode;

--- a/Yijing.maui/Views/SettingsView.xaml.cs
+++ b/Yijing.maui/Views/SettingsView.xaml.cs
@@ -1,0 +1,318 @@
+using System.Collections.ObjectModel;
+using System.Globalization;
+
+using Yijing.Services;
+
+namespace Yijing.Views;
+
+public partial class SettingsView : ContentView
+{
+	private SettingsNode? _selectedNode;
+	private string _selectedNodeTitle = string.Empty;
+	private string _selectedNodeDescription = string.Empty;
+	private bool _isAiPreferencesSelected;
+	private string _aiTemperatureText = string.Empty;
+	private string _aiTopPText = string.Empty;
+	private string _aiMaxTokensText = string.Empty;
+	private string _newServiceName = string.Empty;
+
+	public ObservableCollection<SettingsNode> PropertyNodes { get; } = new();
+	public ObservableCollection<AiServiceEditor> AiServices { get; } = new();
+
+	public SettingsView()
+	{
+		InitializeComponent();
+		BindingContext = this;
+
+		BuildPropertyNodes();
+		SelectedNode = PropertyNodes.FirstOrDefault(node => node.Section == SettingsSection.AiPreferences);
+		propertyTree.SelectedItem = SelectedNode;
+		LoadAiPreferences();
+	}
+
+	public SettingsNode? SelectedNode
+	{
+		get => _selectedNode;
+		set
+		{
+			if (_selectedNode == value)
+				return;
+
+			_selectedNode = value;
+			UpdateSelectedNode();
+			OnPropertyChanged(nameof(SelectedNode));
+		}
+	}
+
+	public string SelectedNodeTitle
+	{
+		get => _selectedNodeTitle;
+		private set
+		{
+			if (_selectedNodeTitle == value)
+				return;
+
+			_selectedNodeTitle = value;
+			OnPropertyChanged(nameof(SelectedNodeTitle));
+		}
+	}
+
+	public string SelectedNodeDescription
+	{
+		get => _selectedNodeDescription;
+		private set
+		{
+			if (_selectedNodeDescription == value)
+				return;
+
+			_selectedNodeDescription = value;
+			OnPropertyChanged(nameof(SelectedNodeDescription));
+		}
+	}
+
+	public bool IsAiPreferencesSelected
+	{
+		get => _isAiPreferencesSelected;
+		private set
+		{
+			if (_isAiPreferencesSelected == value)
+				return;
+
+			_isAiPreferencesSelected = value;
+			OnPropertyChanged(nameof(IsAiPreferencesSelected));
+		}
+	}
+
+	public string AiTemperatureText
+	{
+		get => _aiTemperatureText;
+		set
+		{
+			if (_aiTemperatureText == value)
+				return;
+
+			_aiTemperatureText = value;
+			OnPropertyChanged(nameof(AiTemperatureText));
+		}
+	}
+
+	public string AiTopPText
+	{
+		get => _aiTopPText;
+		set
+		{
+			if (_aiTopPText == value)
+				return;
+
+			_aiTopPText = value;
+			OnPropertyChanged(nameof(AiTopPText));
+		}
+	}
+
+	public string AiMaxTokensText
+	{
+		get => _aiMaxTokensText;
+		set
+		{
+			if (_aiMaxTokensText == value)
+				return;
+
+			_aiMaxTokensText = value;
+			OnPropertyChanged(nameof(AiMaxTokensText));
+		}
+	}
+
+	public string NewServiceName
+	{
+		get => _newServiceName;
+		set
+		{
+			if (_newServiceName == value)
+				return;
+
+			_newServiceName = value;
+			OnPropertyChanged(nameof(NewServiceName));
+		}
+	}
+
+	private void BuildPropertyNodes()
+	{
+		PropertyNodes.Clear();
+		PropertyNodes.Add(new SettingsNode("Application", "", 0, SettingsSection.None, false));
+		PropertyNodes.Add(new SettingsNode(
+			"AI Preferences",
+			"Configure AI services and generation settings.",
+			1,
+			SettingsSection.AiPreferences,
+			true));
+	}
+
+	private void UpdateSelectedNode()
+	{
+		if (_selectedNode is null)
+			return;
+
+		SelectedNodeTitle = _selectedNode.Title;
+		SelectedNodeDescription = _selectedNode.Description;
+		IsAiPreferencesSelected = _selectedNode.Section == SettingsSection.AiPreferences;
+	}
+
+	private void LoadAiPreferences()
+	{
+		AiTemperatureText = AiPreferences.AiTemperature.ToString(CultureInfo.InvariantCulture);
+		AiTopPText = AiPreferences.AiTopP.ToString(CultureInfo.InvariantCulture);
+		AiMaxTokensText = AiPreferences.AiMaxTokens.ToString(CultureInfo.InvariantCulture);
+		NewServiceName = string.Empty;
+
+		AiServices.Clear();
+		foreach (var serviceName in AiPreferences.AiServiceNames)
+		{
+			var info = AiPreferences.AiService(serviceName);
+			AiServices.Add(new AiServiceEditor
+			{
+				Name = serviceName,
+				ModelId = info.ModelId,
+				EndPoint = info.EndPoint,
+				Key = info.Key
+			});
+		}
+	}
+
+	private void OnPropertySelectionChanged(object sender, SelectionChangedEventArgs e)
+	{
+		if (e.CurrentSelection.FirstOrDefault() is SettingsNode node)
+		{
+			if (!node.IsSelectable)
+			{
+				propertyTree.SelectedItem = _selectedNode;
+				return;
+			}
+
+			SelectedNode = node;
+		}
+	}
+
+	private void OnSaveClicked(object sender, EventArgs e)
+	{
+		var serviceNames = new List<string>();
+		var serviceMap = new Dictionary<string, AiPreferences.AiServiceInfo>(StringComparer.OrdinalIgnoreCase);
+
+		foreach (var service in AiServices)
+		{
+			if (string.IsNullOrWhiteSpace(service.Name))
+				continue;
+
+			var name = service.Name.Trim();
+			if (name.Equals(AiPreferences.AiServiceNone, StringComparison.OrdinalIgnoreCase))
+				continue;
+
+			if (serviceMap.ContainsKey(name))
+				continue;
+
+			serviceNames.Add(name);
+			serviceMap[name] = new AiPreferences.AiServiceInfo(
+				service.ModelId?.Trim() ?? string.Empty,
+				service.EndPoint?.Trim() ?? string.Empty,
+				service.Key ?? string.Empty);
+		}
+
+		AiPreferences.AiServiceNames = serviceNames.ToArray();
+		AiPreferences.AiServices = serviceMap;
+		AiPreferences.AiTemperature = ParseFloat(AiTemperatureText, AiPreferences.AiTemperature);
+		AiPreferences.AiTopP = ParseFloat(AiTopPText, AiPreferences.AiTopP);
+		AiPreferences.AiMaxTokens = ParseInt(AiMaxTokensText, AiPreferences.AiMaxTokens);
+
+		AiPreferences.Save();
+		AppPreferences.AiChatService = AiPreferences.NormalizeServiceName(AppPreferences.AiChatService);
+		AppPreferences.AiEegService = AiPreferences.NormalizeServiceName(AppPreferences.AiEegService);
+		LoadAiPreferences();
+	}
+
+	private void OnResetClicked(object sender, EventArgs e)
+	{
+		AiPreferences.Reset();
+		AppPreferences.AiChatService = AiPreferences.NormalizeServiceName(AppPreferences.AiChatService);
+		AppPreferences.AiEegService = AiPreferences.NormalizeServiceName(AppPreferences.AiEegService);
+		LoadAiPreferences();
+	}
+
+	private void OnAddServiceClicked(object sender, EventArgs e)
+	{
+		var name = NewServiceName?.Trim();
+		if (string.IsNullOrWhiteSpace(name))
+			return;
+
+		if (AiServices.Any(service => service.Name.Equals(name, StringComparison.OrdinalIgnoreCase)))
+			return;
+
+		AiServices.Add(new AiServiceEditor { Name = name });
+		NewServiceName = string.Empty;
+	}
+
+	private void OnDeleteServiceClicked(object sender, EventArgs e)
+	{
+		if (sender is not Button button)
+			return;
+
+		if (button.CommandParameter is not AiServiceEditor service)
+			return;
+
+		AiServices.Remove(service);
+	}
+
+	private static float ParseFloat(string value, float fallback)
+	{
+		if (float.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out float parsed))
+			return parsed;
+
+		if (float.TryParse(value, NumberStyles.Float, CultureInfo.CurrentCulture, out parsed))
+			return parsed;
+
+		return fallback;
+	}
+
+	private static int ParseInt(string value, int fallback)
+	{
+		if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsed))
+			return parsed;
+
+		if (int.TryParse(value, NumberStyles.Integer, CultureInfo.CurrentCulture, out parsed))
+			return parsed;
+
+		return fallback;
+	}
+
+	
+}
+
+public enum SettingsSection
+{
+	None,
+	AiPreferences
+}
+
+public class SettingsNode
+{
+	public SettingsNode(string title, string description, int level, SettingsSection section, bool isSelectable)
+	{
+		Title = title;
+		Description = description;
+		Section = section;
+		IsSelectable = isSelectable;
+		Indent = new Thickness(level * 16, 6, 6, 6);
+	}
+
+	public string Title { get; }
+	public string Description { get; }
+	public SettingsSection Section { get; }
+	public bool IsSelectable { get; }
+	public Thickness Indent { get; }
+}
+
+public class AiServiceEditor
+{
+	public string Name { get; set; } = string.Empty;
+	public string ModelId { get; set; } = string.Empty;
+	public string EndPoint { get; set; } = string.Empty;
+	public string Key { get; set; } = string.Empty;
+}


### PR DESCRIPTION
### Motivation
- Provide a settings UI similar to a project properties window to view and edit application properties via a tree and editor pane. 
- Expose AI configuration (AiPreferences) so users can edit generation settings and manage AI provider entries (add/delete). 
- Add Save/Reset actions that persist to the existing `AiPreferences` API and make the Settings page reachable from the app menu.

### Description
- Added a new `SettingsPage` (`Yijing.maui/Pages/SettingsPage.xaml` and `.xaml.cs`) that hosts the settings view and integrates with the existing `MenuView`. 
- Implemented `SettingsView` (`Yijing.maui/Views/SettingsView.xaml` and `.xaml.cs`) which builds a left-hand property tree and a right-hand editor area bound to properties such as `AiTemperatureText`, `AiTopPText`, `AiMaxTokensText`, and an editable `AiServices` collection. 
- Implemented UI handlers to `OnSaveClicked` and `OnResetClicked` that call `AiPreferences.Save()` and `AiPreferences.Reset()` respectively and update `AppPreferences` selections via `AiPreferences.NormalizeServiceName`. 
- Implemented add/delete functionality for AI providers in the view (`OnAddServiceClicked`, `OnDeleteServiceClicked`) and wired navigation by adding a Settings entry to `AppShell.xaml` and a Settings button to `MenuView..cs`.
- Files added/modified: `Yijing.maui/Pages/SettingsPage.xaml`, `Yijing.maui/Pages/SettingsPage.xaml.cs`, `Yijing.maui/Views/SettingsView.xaml`, `Yijing.maui/Views/SettingsView.xaml.cs`, `Yijing.maui/AppShell.xaml`, `Yijing.maui/Views/MenuView..cs`.

### Testing
- No automated tests were executed for these UI changes. 
- No automated build/test run was performed in this patch; changes are UI-centric and require running the MAUI app to validate layout and behavior on target platforms.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69782fff8360832ba80125bda9289f2f)