### PR TITLE
Add Settings page for AI preferences management

### DIFF
--- a/Yijing.maui/AppShell.xaml
+++ b/Yijing.maui/AppShell.xaml
@@ -48,4 +48,14 @@
 			Route="MeditationRoot" />
 	</FlyoutItem>
 
+	<FlyoutItem Route="Settings">
+		<ShellContent
+			x:Name="pagSettings"
+			Shell.NavBarIsVisible="false"
+			Title="Settings"
+			Icon="iconlistdetail.png"
+			ContentTemplate="{DataTemplate pages:SettingsPage}"
+			Route="SettingsRoot" />
+	</FlyoutItem>
+
 </Shell>

--- a/Yijing.maui/Pages/SettingsPage.xaml
+++ b/Yijing.maui/Pages/SettingsPage.xaml
@@ -120,9 +120,11 @@
 							BindableLayout.ItemsSource="{Binding ServiceItems}">
 							<BindableLayout.ItemTemplate>
 								<DataTemplate>
-									<Border Padding="12">
-										<Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
-											<VerticalStackLayout Spacing="8">
+										<Border Padding="12">
+											<Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+												<VerticalStackLayout
+													Grid.Column="0"
+													Spacing="8">
 												<Grid ColumnDefinitions="Auto,*" ColumnSpacing="12">
 													<Label
 														Text="Name"
@@ -160,11 +162,12 @@
 												</Grid>
 											</VerticalStackLayout>
 
-											<controls:ButtonEx
-												Icon="{x:Static controls:FluentIcons.Delete}"
-												Clicked="OnDeleteServiceClicked" />
-										</Grid>
-									</Border>
+												<controls:ButtonEx
+													Grid.Column="1"
+													Icon="{x:Static controls:FluentIcons.Delete}"
+													Clicked="OnDeleteServiceClicked" />
+											</Grid>
+										</Border>
 								</DataTemplate>
 							</BindableLayout.ItemTemplate>
 						</VerticalStackLayout>

--- a/Yijing.maui/Pages/SettingsPage.xaml
+++ b/Yijing.maui/Pages/SettingsPage.xaml
@@ -130,6 +130,7 @@
 														Text="Name"
 														VerticalTextAlignment="Center" />
 													<Entry
+														Grid.Column="1"
 														Text="{Binding Name}"
 														HorizontalOptions="Fill" />
 												</Grid>
@@ -139,6 +140,7 @@
 														Text="Model"
 														VerticalTextAlignment="Center" />
 													<Entry
+														Grid.Column="1"
 														Text="{Binding ModelId}"
 														HorizontalOptions="Fill" />
 												</Grid>
@@ -148,6 +150,7 @@
 														Text="Endpoint"
 														VerticalTextAlignment="Center" />
 													<Entry
+														Grid.Column="1"
 														Text="{Binding EndPoint}"
 														HorizontalOptions="Fill" />
 												</Grid>
@@ -157,6 +160,7 @@
 														Text="Key"
 														VerticalTextAlignment="Center" />
 													<Entry
+														Grid.Column="1"
 														Text="{Binding Key}"
 														HorizontalOptions="Fill" />
 												</Grid>

--- a/Yijing.maui/Pages/SettingsPage.xaml
+++ b/Yijing.maui/Pages/SettingsPage.xaml
@@ -125,7 +125,7 @@
 												<VerticalStackLayout
 													Grid.Column="0"
 													Spacing="8">
-													<Grid ColumnDefinitions="120,*" ColumnSpacing="12">
+													<Grid ColumnDefinitions="80,*" ColumnSpacing="12">
 													<Label
 														Text="Name"
 														VerticalTextAlignment="Center" />
@@ -135,7 +135,7 @@
 														HorizontalOptions="Fill" />
 												</Grid>
 
-													<Grid ColumnDefinitions="120,*" ColumnSpacing="12">
+													<Grid ColumnDefinitions="80,*" ColumnSpacing="12">
 													<Label
 														Text="Model"
 														VerticalTextAlignment="Center" />
@@ -145,7 +145,7 @@
 														HorizontalOptions="Fill" />
 												</Grid>
 
-													<Grid ColumnDefinitions="120,*" ColumnSpacing="12">
+													<Grid ColumnDefinitions="80,*" ColumnSpacing="12">
 													<Label
 														Text="Endpoint"
 														VerticalTextAlignment="Center" />
@@ -155,7 +155,7 @@
 														HorizontalOptions="Fill" />
 												</Grid>
 
-													<Grid ColumnDefinitions="120,*" ColumnSpacing="12">
+													<Grid ColumnDefinitions="80,*" ColumnSpacing="12">
 													<Label
 														Text="Key"
 														VerticalTextAlignment="Center" />

--- a/Yijing.maui/Pages/SettingsPage.xaml
+++ b/Yijing.maui/Pages/SettingsPage.xaml
@@ -115,13 +115,10 @@
 								Clicked="OnAddServiceClicked" />
 						</HorizontalStackLayout>
 
-						<CollectionView
-							x:Name="colServices"
-							ItemsSource="{Binding ServiceItems}">
-							<CollectionView.ItemsLayout>
-								<LinearItemsLayout Orientation="Vertical" ItemSpacing="10" />
-							</CollectionView.ItemsLayout>
-							<CollectionView.ItemTemplate>
+						<VerticalStackLayout
+							Spacing="10"
+							BindableLayout.ItemsSource="{Binding ServiceItems}">
+							<BindableLayout.ItemTemplate>
 								<DataTemplate>
 									<Border Padding="12">
 										<Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
@@ -169,8 +166,8 @@
 										</Grid>
 									</Border>
 								</DataTemplate>
-							</CollectionView.ItemTemplate>
-						</CollectionView>
+							</BindableLayout.ItemTemplate>
+						</VerticalStackLayout>
 					</VerticalStackLayout>
 				</VerticalStackLayout>
 			</ScrollView>

--- a/Yijing.maui/Pages/SettingsPage.xaml
+++ b/Yijing.maui/Pages/SettingsPage.xaml
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<ContentPage
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+
+	xmlns:views="clr-namespace:Yijing.Views"
+	xmlns:controls="clr-namespace:Yijing.Controls"
+
+	x:Class="Yijing.Pages.SettingsPage"
+	Loaded="Page_Loaded">
+
+	<toolkit:DockLayout
+		x:Name="layDock"
+		ShouldExpandLastChild="true">
+
+		<views:MenuView
+			x:Name="horMenu"
+			toolkit:DockLayout.DockPosition="Bottom" />
+
+		<views:MenuView
+			x:Name="verMenu"
+			toolkit:DockLayout.DockPosition="{x:Static views:MenuView.VerticalDockPosition}" />
+
+		<views:SettingsView
+			x:Name="settingsView"
+			toolkit:DockLayout.DockPosition="Left"
+			WidthRequest="300"
+			SectionSelected="SettingsView_SectionSelected"
+			SaveClicked="SettingsView_SaveClicked"
+			ResetClicked="SettingsView_ResetClicked" />
+
+		<Border x:Name="borDetails">
+			<ScrollView>
+				<VerticalStackLayout
+					x:Name="vslDetails"
+					Padding="20"
+					Spacing="16">
+					<VerticalStackLayout Spacing="6">
+						<Label
+							x:Name="lblSectionTitle"
+							FontSize="28"
+							Text="AI Preferences" />
+						<BoxView
+							x:Name="bxSectionSeparator"
+							HeightRequest="1"
+							Color="Gray" />
+						<Label
+							x:Name="lblSectionDescription"
+							Text="Configure AI provider defaults and services for chat and EEG analysis."
+							FontSize="13"
+							TextColor="Gray" />
+					</VerticalStackLayout>
+
+					<VerticalStackLayout Spacing="10">
+						<Label
+							Text="Defaults"
+							FontAttributes="Bold" />
+						<Grid
+							ColumnDefinitions="Auto,*"
+							RowDefinitions="Auto,Auto,Auto"
+							ColumnSpacing="12"
+							RowSpacing="10">
+							<Label
+								Grid.Row="0"
+								Grid.Column="0"
+								Text="Temperature"
+								VerticalTextAlignment="Center" />
+							<Entry
+								x:Name="edtAiTemperature"
+								Grid.Row="0"
+								Grid.Column="1"
+								Keyboard="Numeric" />
+
+							<Label
+								Grid.Row="1"
+								Grid.Column="0"
+								Text="Top P"
+								VerticalTextAlignment="Center" />
+							<Entry
+								x:Name="edtAiTopP"
+								Grid.Row="1"
+								Grid.Column="1"
+								Keyboard="Numeric" />
+
+							<Label
+								Grid.Row="2"
+								Grid.Column="0"
+								Text="Max Tokens"
+								VerticalTextAlignment="Center" />
+							<Entry
+								x:Name="edtAiMaxTokens"
+								Grid.Row="2"
+								Grid.Column="1"
+								Keyboard="Numeric" />
+						</Grid>
+					</VerticalStackLayout>
+
+					<VerticalStackLayout Spacing="10">
+						<Label
+							Text="AI Services"
+							FontAttributes="Bold" />
+						<Label
+							Text="Add or remove providers and edit their model, endpoint, and key."
+							FontSize="13"
+							TextColor="Gray" />
+
+						<HorizontalStackLayout Spacing="8">
+							<Entry
+								x:Name="edtNewServiceName"
+								Placeholder="New service name" />
+							<controls:ButtonEx
+								Icon="{x:Static controls:FluentIcons.Add}"
+								Clicked="OnAddServiceClicked" />
+						</HorizontalStackLayout>
+
+						<CollectionView
+							x:Name="colServices"
+							ItemsSource="{Binding ServiceItems}">
+							<CollectionView.ItemsLayout>
+								<LinearItemsLayout Orientation="Vertical" ItemSpacing="10" />
+							</CollectionView.ItemsLayout>
+							<CollectionView.ItemTemplate>
+								<DataTemplate>
+									<Border Padding="12">
+										<Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+											<VerticalStackLayout Spacing="8">
+												<Grid ColumnDefinitions="Auto,*" ColumnSpacing="12">
+													<Label
+														Text="Name"
+														VerticalTextAlignment="Center" />
+													<Entry
+														Text="{Binding Name}"
+														HorizontalOptions="Fill" />
+												</Grid>
+
+												<Grid ColumnDefinitions="Auto,*" ColumnSpacing="12">
+													<Label
+														Text="Model"
+														VerticalTextAlignment="Center" />
+													<Entry
+														Text="{Binding ModelId}"
+														HorizontalOptions="Fill" />
+												</Grid>
+
+												<Grid ColumnDefinitions="Auto,*" ColumnSpacing="12">
+													<Label
+														Text="Endpoint"
+														VerticalTextAlignment="Center" />
+													<Entry
+														Text="{Binding EndPoint}"
+														HorizontalOptions="Fill" />
+												</Grid>
+
+												<Grid ColumnDefinitions="Auto,*" ColumnSpacing="12">
+													<Label
+														Text="Key"
+														VerticalTextAlignment="Center" />
+													<Entry
+														Text="{Binding Key}"
+														HorizontalOptions="Fill" />
+												</Grid>
+											</VerticalStackLayout>
+
+											<controls:ButtonEx
+												Icon="{x:Static controls:FluentIcons.Delete}"
+												Clicked="OnDeleteServiceClicked" />
+										</Grid>
+									</Border>
+								</DataTemplate>
+							</CollectionView.ItemTemplate>
+						</CollectionView>
+					</VerticalStackLayout>
+				</VerticalStackLayout>
+			</ScrollView>
+		</Border>
+	</toolkit:DockLayout>
+</ContentPage>

--- a/Yijing.maui/Pages/SettingsPage.xaml
+++ b/Yijing.maui/Pages/SettingsPage.xaml
@@ -125,7 +125,7 @@
 												<VerticalStackLayout
 													Grid.Column="0"
 													Spacing="8">
-												<Grid ColumnDefinitions="Auto,*" ColumnSpacing="12">
+													<Grid ColumnDefinitions="120,*" ColumnSpacing="12">
 													<Label
 														Text="Name"
 														VerticalTextAlignment="Center" />
@@ -135,7 +135,7 @@
 														HorizontalOptions="Fill" />
 												</Grid>
 
-												<Grid ColumnDefinitions="Auto,*" ColumnSpacing="12">
+													<Grid ColumnDefinitions="120,*" ColumnSpacing="12">
 													<Label
 														Text="Model"
 														VerticalTextAlignment="Center" />
@@ -145,7 +145,7 @@
 														HorizontalOptions="Fill" />
 												</Grid>
 
-												<Grid ColumnDefinitions="Auto,*" ColumnSpacing="12">
+													<Grid ColumnDefinitions="120,*" ColumnSpacing="12">
 													<Label
 														Text="Endpoint"
 														VerticalTextAlignment="Center" />
@@ -155,7 +155,7 @@
 														HorizontalOptions="Fill" />
 												</Grid>
 
-												<Grid ColumnDefinitions="Auto,*" ColumnSpacing="12">
+													<Grid ColumnDefinitions="120,*" ColumnSpacing="12">
 													<Label
 														Text="Key"
 														VerticalTextAlignment="Center" />

--- a/Yijing.maui/Pages/SettingsPage.xaml.cs
+++ b/Yijing.maui/Pages/SettingsPage.xaml.cs
@@ -78,7 +78,6 @@ public partial class SettingsPage : ContentPage
 		{
 			borDetails.BackgroundColor = Colors.Black;
 			vslDetails.BackgroundColor = Colors.Black;
-			colServices.BackgroundColor = Colors.Black;
 		}
 
 		LoadAiPreferences();

--- a/Yijing.maui/Pages/SettingsPage.xaml.cs
+++ b/Yijing.maui/Pages/SettingsPage.xaml.cs
@@ -1,0 +1,276 @@
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Threading.Tasks;
+using System.Linq;
+
+using Yijing.Services;
+using Yijing.Views;
+
+namespace Yijing.Pages;
+
+public partial class SettingsPage : ContentPage
+{
+	public class AiServiceEditor : BindableObject
+	{
+		private string _name = string.Empty;
+		private string _modelId = string.Empty;
+		private string _endPoint = string.Empty;
+		private string _key = string.Empty;
+
+		public string Name
+		{
+			get => _name;
+			set
+			{
+				if (_name == value)
+					return;
+				_name = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public string ModelId
+		{
+			get => _modelId;
+			set
+			{
+				if (_modelId == value)
+					return;
+				_modelId = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public string EndPoint
+		{
+			get => _endPoint;
+			set
+			{
+				if (_endPoint == value)
+					return;
+				_endPoint = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public string Key
+		{
+			get => _key;
+			set
+			{
+				if (_key == value)
+					return;
+				_key = value;
+				OnPropertyChanged();
+			}
+		}
+	}
+
+	public ObservableCollection<AiServiceEditor> ServiceItems { get; } = new();
+
+	public SettingsPage()
+	{
+		Behaviors.Add(new RegisterInViewDirectoryBehavior());
+		InitializeComponent();
+		BindingContext = this;
+
+		if (App.Current!.RequestedTheme == AppTheme.Dark)
+		{
+			borDetails.BackgroundColor = Colors.Black;
+			vslDetails.BackgroundColor = Colors.Black;
+			colServices.BackgroundColor = Colors.Black;
+		}
+
+		LoadAiPreferences();
+
+		horMenu.Create(ePages.eSettings, StackOrientation.Horizontal);
+		verMenu.Create(ePages.eSettings, StackOrientation.Vertical);
+	}
+
+	private void Page_Loaded(object sender, EventArgs e)
+	{
+	}
+
+	protected override void OnSizeAllocated(double width, double height)
+	{
+		if ((width == -1) || (height == -1))
+			return;
+
+#if ANDROID || IOS
+		if (width > height)
+		{
+			horMenu.IsVisible = false;
+			verMenu.IsVisible = true;
+			settingsView.WidthRequest = 200;
+			settingsView.ButtonPadding(new Thickness(0, 5));
+		}
+		else
+		{
+			horMenu.IsVisible = true;
+			verMenu.IsVisible = false;
+			settingsView.WidthRequest = width;
+			settingsView.ButtonPadding(new Thickness(5));
+		}
+#else
+		horMenu.IsVisible = false;
+		verMenu.IsVisible = true;
+#endif
+
+		base.OnSizeAllocated(width, height);
+	}
+
+	private void SettingsView_SectionSelected(object sender, SettingsSection section)
+	{
+		if (section == SettingsSection.AiPreferences)
+		{
+			lblSectionTitle.Text = "AI Preferences";
+			lblSectionDescription.Text = "Configure AI provider defaults and services for chat and EEG analysis.";
+		}
+	}
+
+	private async void SettingsView_SaveClicked(object sender, EventArgs e)
+	{
+		if (!await TryApplyPreferences())
+			return;
+
+		AiPreferences.Save();
+		AppPreferences.AiChatService = AiPreferences.NormalizeServiceName(AppPreferences.AiChatService);
+		AppPreferences.AiEegService = AiPreferences.NormalizeServiceName(AppPreferences.AiEegService);
+	}
+
+	private void SettingsView_ResetClicked(object sender, EventArgs e)
+	{
+		AiPreferences.Reset();
+		LoadAiPreferences();
+	}
+
+	private async void OnAddServiceClicked(object sender, EventArgs e)
+	{
+		string name = edtNewServiceName.Text?.Trim() ?? string.Empty;
+		if (string.IsNullOrWhiteSpace(name))
+		{
+			await DisplayAlert("AI Services", "Enter a service name before adding.", "OK");
+			return;
+		}
+
+		if (ServiceItems.Any(item => string.Equals(item.Name, name, StringComparison.OrdinalIgnoreCase)))
+		{
+			await DisplayAlert("AI Services", "That service already exists.", "OK");
+			return;
+		}
+
+		ServiceItems.Add(new AiServiceEditor
+		{
+			Name = name,
+			ModelId = string.Empty,
+			EndPoint = string.Empty,
+			Key = string.Empty
+		});
+
+		edtNewServiceName.Text = string.Empty;
+	}
+
+	private async void OnDeleteServiceClicked(object sender, EventArgs e)
+	{
+		if (sender is not Button button || button.BindingContext is not AiServiceEditor item)
+			return;
+
+		bool confirm = await DisplayAlert("Delete Service", $"Delete {item.Name}?", "Yes", "No");
+		if (!confirm)
+			return;
+
+		ServiceItems.Remove(item);
+	}
+
+	private void LoadAiPreferences()
+	{
+		ServiceItems.Clear();
+
+		foreach (var serviceName in AiPreferences.AiServiceNames)
+		{
+			if (!AiPreferences.AiServices.TryGetValue(serviceName, out var info))
+				info = new AiPreferences.AiServiceInfo(string.Empty, string.Empty, string.Empty);
+
+			ServiceItems.Add(new AiServiceEditor
+			{
+				Name = serviceName,
+				ModelId = info.ModelId,
+				EndPoint = info.EndPoint,
+				Key = info.Key
+			});
+		}
+
+		edtAiTemperature.Text = AiPreferences.AiTemperature.ToString(CultureInfo.InvariantCulture);
+		edtAiTopP.Text = AiPreferences.AiTopP.ToString(CultureInfo.InvariantCulture);
+		edtAiMaxTokens.Text = AiPreferences.AiMaxTokens.ToString(CultureInfo.InvariantCulture);
+	}
+
+	private async Task<bool> TryApplyPreferences()
+	{
+		if (!TryParseFloat(edtAiTemperature.Text, out float temperature))
+		{
+			await DisplayAlert("AI Preferences", "Temperature must be a number.", "OK");
+			return false;
+		}
+
+		if (!TryParseFloat(edtAiTopP.Text, out float topP))
+		{
+			await DisplayAlert("AI Preferences", "Top P must be a number.", "OK");
+			return false;
+		}
+
+		if (!int.TryParse(edtAiMaxTokens.Text, NumberStyles.Integer, CultureInfo.InvariantCulture, out int maxTokens))
+		{
+			await DisplayAlert("AI Preferences", "Max Tokens must be a whole number.", "OK");
+			return false;
+		}
+
+		var names = new List<string>();
+		var serviceInfos = new Dictionary<string, AiPreferences.AiServiceInfo>(StringComparer.OrdinalIgnoreCase);
+		var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+		foreach (var item in ServiceItems)
+		{
+			string name = item.Name?.Trim() ?? string.Empty;
+			if (string.IsNullOrWhiteSpace(name))
+			{
+				await DisplayAlert("AI Services", "Service names cannot be blank.", "OK");
+				return false;
+			}
+
+			if (string.Equals(name, AiPreferences.AiServiceNone, StringComparison.OrdinalIgnoreCase))
+			{
+				await DisplayAlert("AI Services", "Service name 'None' is reserved.", "OK");
+				return false;
+			}
+
+			if (!seen.Add(name))
+			{
+				await DisplayAlert("AI Services", $"Duplicate service name: {name}.", "OK");
+				return false;
+			}
+
+			names.Add(name);
+			serviceInfos[name] = new AiPreferences.AiServiceInfo(
+				item.ModelId?.Trim() ?? string.Empty,
+				item.EndPoint?.Trim() ?? string.Empty,
+				item.Key ?? string.Empty);
+		}
+
+		AiPreferences.AiTemperature = temperature;
+		AiPreferences.AiTopP = topP;
+		AiPreferences.AiMaxTokens = maxTokens;
+		AiPreferences.AiServiceNames = names.ToArray();
+		AiPreferences.AiServices = serviceInfos;
+
+		return true;
+	}
+
+	private static bool TryParseFloat(string? value, out float result)
+	{
+		if (float.TryParse(value, NumberStyles.Float, CultureInfo.CurrentCulture, out result))
+			return true;
+
+		return float.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out result);
+	}
+}

--- a/Yijing.maui/Views/MenuView..cs
+++ b/Yijing.maui/Views/MenuView..cs
@@ -15,6 +15,7 @@ public partial class MenuView : ContentView
 	private ButtonEx _btnDiagram;
 	private ButtonEx _btnEeg;
 	private ButtonEx _btnMeditation;
+	private ButtonEx _btnSettings;
 
 
 #if WINDOWS || MACCATALYST
@@ -80,6 +81,10 @@ public partial class MenuView : ContentView
 		{
 			Icon = FluentIcons.MeditationPage,
 		};
+		_btnSettings = new ButtonEx()
+		{
+			Icon = FluentIcons.Setting,
+		};
 
 		if (orientation == StackOrientation.Vertical)
 #if WINDOWS || MACCATALYST
@@ -96,11 +101,13 @@ public partial class MenuView : ContentView
 		_slMenu.Children.Add(_btnDiagram);
 		_slMenu.Children.Add(_btnEeg);
 		_slMenu.Children.Add(_btnMeditation);
+		_slMenu.Children.Add(_btnSettings);
 
 		_btnSession.Clicked += btnSession_Clicked;
 		_btnDiagram.Clicked += btnDiagram_Clicked;
 		_btnEeg.Clicked += btnEeg_Clicked;
 		_btnMeditation.Clicked += btnMeditation_Clicked;
+		_btnSettings.Clicked += btnSettings_Clicked;
 
 		Content = border;
 	}
@@ -128,6 +135,12 @@ public partial class MenuView : ContentView
 	{
 		if (_ePage != ePages.eMeditation)
 			await Shell.Current.GoToAsync("//Meditation/MeditationRoot", true);
+	}
+
+	private async void btnSettings_Clicked(object sender, EventArgs e)
+	{
+		if (_ePage != ePages.eSettings)
+			await Shell.Current.GoToAsync("//Settings/SettingsRoot", true);
 	}
 
 	public static readonly BindableProperty CardColorProperty = BindableProperty.Create(nameof(CardColor),

--- a/Yijing.maui/Views/SessionView.xaml
+++ b/Yijing.maui/Views/SessionView.xaml
@@ -24,19 +24,21 @@
 	</ContentView.Resources>
 
 	<Border>
-		<Grid RowDefinitions="Auto,*">
-			<HorizontalStackLayout
-				x:Name="hslButtons"
-				Grid.Row="0">
-				<controls:ButtonEx
-					x:Name="btnAdd"
-					Icon="{x:Static controls:FluentIcons.Add}"
-					Clicked="OnAddSessionClicked" />
-				<controls:ButtonEx
-					x:Name="btnDelete"
-					Icon="{x:Static controls:FluentIcons.Delete}"
-					Clicked="OnDeleteSessionClicked" />
-			</HorizontalStackLayout>
+		<Grid RowDefinitions="Auto,*" >
+			<Border>
+				<HorizontalStackLayout
+					x:Name="hslButtons"
+					Grid.Row="0">
+					<controls:ButtonEx
+						x:Name="btnAdd"
+						Icon="{x:Static controls:FluentIcons.Add}"
+						Clicked="OnAddSessionClicked" />
+					<controls:ButtonEx
+						x:Name="btnDelete"
+						Icon="{x:Static controls:FluentIcons.Delete}"
+						Clicked="OnDeleteSessionClicked" />
+				</HorizontalStackLayout>
+			</Border>
 
 			<CollectionView
 				x:Name="sessionCollection"

--- a/Yijing.maui/Views/SettingsView.xaml
+++ b/Yijing.maui/Views/SettingsView.xaml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<ContentView
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+	
+	xmlns:controls="clr-namespace:Yijing.Controls"
+	xmlns:views="clr-namespace:Yijing.Views"
+	
+	x:Class="Yijing.Views.SettingsView"
+	x:Name="settingsView">
+
+	<Border>
+		<Grid RowDefinitions="Auto,*">
+			<HorizontalStackLayout
+				x:Name="hslButtons"
+				Grid.Row="0">
+				<controls:ButtonEx
+					x:Name="btnSave"
+					Icon="{x:Static controls:FluentIcons.Save}"
+					Clicked="OnSaveClicked" />
+				<controls:ButtonEx
+					x:Name="btnReset"
+					Icon="{x:Static controls:FluentIcons.Restore}"
+					Clicked="OnResetClicked" />
+			</HorizontalStackLayout>
+
+			<CollectionView
+				x:Name="settingsTree"
+				Grid.Row="1"
+				ItemsSource="{Binding TreeItems}"
+				SelectionMode="Single"
+				SelectionChanged="OnSelectionChanged">
+				<CollectionView.ItemsLayout>
+					<LinearItemsLayout Orientation="Vertical" />
+				</CollectionView.ItemsLayout>
+
+				<CollectionView.ItemTemplate>
+					<DataTemplate x:DataType="views:SettingsTreeItem">
+						<Label
+							Text="{Binding Title}"
+							FontAttributes="{Binding FontAttributes}"
+							Margin="{Binding ItemMargin}" />
+					</DataTemplate>
+				</CollectionView.ItemTemplate>
+			</CollectionView>
+		</Grid>
+	</Border>
+</ContentView>

--- a/Yijing.maui/Views/SettingsView.xaml
+++ b/Yijing.maui/Views/SettingsView.xaml
@@ -13,18 +13,20 @@
 
 	<Border>
 		<Grid RowDefinitions="Auto,*">
-			<HorizontalStackLayout
-				x:Name="hslButtons"
-				Grid.Row="0">
-				<controls:ButtonEx
-					x:Name="btnSave"
-					Icon="{x:Static controls:FluentIcons.Save}"
-					Clicked="OnSaveClicked" />
-				<controls:ButtonEx
-					x:Name="btnReset"
-					Icon="{x:Static controls:FluentIcons.Restore}"
-					Clicked="OnResetClicked" />
-			</HorizontalStackLayout>
+			<Border>
+				<HorizontalStackLayout
+					x:Name="hslButtons"
+					Grid.Row="0">
+					<controls:ButtonEx
+						x:Name="btnSave"
+						Icon="{x:Static controls:FluentIcons.Save}"
+						Clicked="OnSaveClicked" />
+					<controls:ButtonEx
+						x:Name="btnReset"
+						Icon="{x:Static controls:FluentIcons.Restore}"
+						Clicked="OnResetClicked" />
+				</HorizontalStackLayout>
+			</Border>
 
 			<CollectionView
 				x:Name="settingsTree"

--- a/Yijing.maui/Views/SettingsView.xaml.cs
+++ b/Yijing.maui/Views/SettingsView.xaml.cs
@@ -1,0 +1,92 @@
+using System.Collections.ObjectModel;
+
+namespace Yijing.Views;
+
+public enum SettingsSection
+{
+	AiPreferences
+}
+
+public class SettingsTreeItem
+{
+	public string Title { get; }
+	public SettingsSection Section { get; }
+	public FontAttributes FontAttributes { get; }
+	public Thickness ItemMargin { get; }
+
+	public SettingsTreeItem(string title, SettingsSection section, FontAttributes fontAttributes, Thickness itemMargin)
+	{
+		Title = title;
+		Section = section;
+		FontAttributes = fontAttributes;
+		ItemMargin = itemMargin;
+	}
+}
+
+public partial class SettingsView : ContentView
+{
+	public ObservableCollection<SettingsTreeItem> TreeItems { get; } = new();
+
+	public event EventHandler<SettingsSection>? SectionSelected;
+	public event EventHandler? SaveClicked;
+	public event EventHandler? ResetClicked;
+
+	public SettingsView()
+	{
+		InitializeComponent();
+		BindingContext = this;
+
+		if (App.Current!.RequestedTheme == AppTheme.Dark)
+		{
+			hslButtons.BackgroundColor = Colors.Black;
+			settingsTree.BackgroundColor = Colors.Black;
+		}
+
+		TreeItems.Add(new SettingsTreeItem("Application", SettingsSection.AiPreferences, FontAttributes.Bold, new Thickness(10, 12, 0, 6)));
+		TreeItems.Add(new SettingsTreeItem("AI Preferences", SettingsSection.AiPreferences, FontAttributes.None, new Thickness(28, 6, 0, 6)));
+
+		settingsTree.SelectedItem = TreeItems[1];
+	}
+
+	protected override void OnSizeAllocated(double width, double height)
+	{
+		if ((width == -1) || (height == -1))
+			return;
+
+		double w = width - 10;
+
+		w = width - 40;
+
+		w /= 2;
+
+		w /= 2;
+		btnSave.WidthRequest = w;
+		btnReset.WidthRequest = w;
+
+		base.OnSizeAllocated(width, height);
+	}
+
+	public void ButtonPadding(Thickness thickness)
+	{
+		btnSave.Padding = thickness;
+		btnReset.Padding = thickness;
+	}
+
+	private void OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+	{
+		if (e.CurrentSelection.FirstOrDefault() is not SettingsTreeItem item)
+			return;
+
+		SectionSelected?.Invoke(this, item.Section);
+	}
+
+	private void OnSaveClicked(object? sender, EventArgs e)
+	{
+		SaveClicked?.Invoke(this, EventArgs.Empty);
+	}
+
+	private void OnResetClicked(object? sender, EventArgs e)
+	{
+		ResetClicked?.Invoke(this, EventArgs.Empty);
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide a Settings UI similar to the Session/Diagram pages so users can view and edit application properties in a left-hand tree with details on the right. 
- Start by exposing AI configuration so users can manage AI defaults and provider entries used elsewhere in the app.

### Description
- Added a new `SettingsPage` and `SettingsView` that mirror the SessionPage layout and resizing behavior with a left-hand property tree, Save/Reset buttons, and a details area for AI Preferences (`Yijing.maui/Pages/SettingsPage.xaml`, `Yijing.maui/Views/SettingsView.xaml`).
- Implemented an AI services editor in `SettingsPage.xaml.cs` that binds a collection of editable `AiServiceEditor` items, supports adding and deleting services, and validates inputs before applying to `AiPreferences`.
- Hooked Save and Reset actions to call `AiPreferences.Save()` and `AiPreferences.Reset()` and update `AppPreferences` normalization logic after save, with user-facing validation and alert dialogs; updated async flows to await alerts where appropriate.
- Added navigation to the Settings page via `AppShell.xaml` and the main `MenuView` by adding a Settings button and route so the page is reachable from the app menu.

### Testing
- No automated tests were executed for this change (UI-only additions); manual validation expected during app runtime and UI testing is required. 
- Basic compile-time checks were not run in this environment and should be performed as part of CI or a local build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ad80f5c10832bb4bd10e597a91232)